### PR TITLE
drop codesandbox-api in favor of a custom solution

### DIFF
--- a/sandpack-client/package.json
+++ b/sandpack-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smooshpack",
-  "version": "1.0.0-beta-4",
+  "version": "1.0.0-beta-5",
   "description": "",
   "keywords": [],
   "repository": {

--- a/sandpack-client/package.json
+++ b/sandpack-client/package.json
@@ -30,7 +30,6 @@
     "README.md"
   ],
   "dependencies": {
-    "codesandbox-api": "^0.0.32",
     "codesandbox-import-utils": "^1.2.3",
     "lodash.isequal": "^4.5.0"
   },

--- a/sandpack-client/src/client.ts
+++ b/sandpack-client/src/client.ts
@@ -15,6 +15,7 @@ import {
   Modules,
   ClientStatus,
 } from './types';
+import Protocol from './file-resolver-protocol';
 
 export interface ClientOptions {
   /**
@@ -81,7 +82,7 @@ export class SandpackClient {
   iframeProtocol: IFrameProtocol;
   options: ClientOptions;
 
-  // fileResolverProtocol?: Protocol;
+  fileResolverProtocol?: Protocol;
   bundlerURL: string;
   bundlerState?: BundlerState;
   errors: Array<ModuleError>;
@@ -147,20 +148,20 @@ export class SandpackClient {
 
         this.iframeProtocol.register();
 
-        // TODO: Figure out the best way to bring this back
-        // if (this.options.fileResolver) {
-        //   this.fileResolverProtocol = new Protocol(
-        //     'file-resolver',
-        //     async (data: { m: 'isFile' | 'readFile'; p: string }) => {
-        //       if (data.m === 'isFile') {
-        //         return this.options.fileResolver!.isFile(data.p);
-        //       }
+        if (this.options.fileResolver) {
+          // TODO: Find a common place for the Protocol to be implemented for both sandpack-core and sandpack-client
+          this.fileResolverProtocol = new Protocol(
+            'file-resolver',
+            async (data: { m: 'isFile' | 'readFile'; p: string }) => {
+              if (data.m === 'isFile') {
+                return this.options.fileResolver!.isFile(data.p);
+              }
 
-        //       return this.options.fileResolver!.readFile(data.p);
-        //     },
-        //     this.iframe.contentWindow
-        //   );
-        // }
+              return this.options.fileResolver!.readFile(data.p);
+            },
+            this.iframe.contentWindow
+          );
+        }
 
         this.updatePreview(this.sandboxInfo, true);
       }

--- a/sandpack-client/src/client.ts
+++ b/sandpack-client/src/client.ts
@@ -1,9 +1,9 @@
-import { dispatch, listen, registerFrame, Protocol } from 'codesandbox-api';
 import { getTemplate } from 'codesandbox-import-utils/lib/create-sandbox/templates';
 
 import isEqual from 'lodash.isequal';
 
 import { createPackageJSON, addPackageJSONIfNeeded } from './utils';
+import { IFrameProtocol } from './iframe-protocol';
 
 // @ts-ignore
 import { version } from '../package.json';
@@ -71,24 +71,26 @@ export interface SandboxInfo {
 
 const BUNDLER_URL =
   process.env.CODESANDBOX_ENV === 'development'
-    ? 'http://localhost:3000'
-    : `https://${version.replace(/\./g, '-')}-sandpack.codesandbox.io`;
+    ? 'http://localhost:3000/'
+    : `https://${version.replace(/\./g, '-')}-sandpack.codesandbox.io/`;
 
 export class SandpackClient {
   selector: string | undefined;
   element: Element;
   iframe: HTMLIFrameElement;
+  iframeProtocol: IFrameProtocol;
   options: ClientOptions;
-  readonly id: number = Math.floor(Math.random() * 1000000);
 
-  listener?: Function;
-  fileResolverProtocol?: Protocol;
+  // fileResolverProtocol?: Protocol;
   bundlerURL: string;
   bundlerState?: BundlerState;
   errors: Array<ModuleError>;
   status: ClientStatus;
 
   sandboxInfo: SandboxInfo;
+
+  unsubscribeGlobalListener: Function;
+  unsubscribeChannelListener: Function;
 
   constructor(
     selector: string | HTMLIFrameElement,
@@ -131,68 +133,73 @@ export class SandpackClient {
     }
 
     this.iframe.src = this.bundlerURL;
-    this.listener = listen((mes: any) => {
-      if (mes.type !== 'initialized' && mes.$id && mes.$id !== this.id) {
-        // This message was not meant for this instance of the client.
-        return;
+    this.iframeProtocol = new IFrameProtocol(this.iframe, this.bundlerURL);
+
+    this.unsubscribeGlobalListener = this.iframeProtocol.globalListen(
+      (mes: any) => {
+        if (
+          mes.type !== 'initialized' ||
+          // mes.url !== this.bundlerURL || TODO: see if it makes sense to match the URL here (eg: routing scenario)
+          !this.iframe.contentWindow
+        ) {
+          return;
+        }
+
+        this.iframeProtocol.register();
+
+        // TODO: Figure out the best way to bring this back
+        // if (this.options.fileResolver) {
+        //   this.fileResolverProtocol = new Protocol(
+        //     'file-resolver',
+        //     async (data: { m: 'isFile' | 'readFile'; p: string }) => {
+        //       if (data.m === 'isFile') {
+        //         return this.options.fileResolver!.isFile(data.p);
+        //       }
+
+        //       return this.options.fileResolver!.readFile(data.p);
+        //     },
+        //     this.iframe.contentWindow
+        //   );
+        // }
+
+        this.updatePreview(this.sandboxInfo, true);
       }
+    );
 
-      switch (mes.type) {
-        case 'initialized': {
-          if (this.iframe) {
-            if (this.iframe.contentWindow) {
-              registerFrame(
-                this.iframe.contentWindow,
-                this.bundlerURL,
-                this.id
-              );
-
-              if (this.options.fileResolver) {
-                this.fileResolverProtocol = new Protocol(
-                  'file-resolver',
-                  async (data: { m: 'isFile' | 'readFile'; p: string }) => {
-                    if (data.m === 'isFile') {
-                      return this.options.fileResolver!.isFile(data.p);
-                    }
-
-                    return this.options.fileResolver!.readFile(data.p);
-                  },
-                  this.iframe.contentWindow
-                );
-              }
+    this.unsubscribeChannelListener = this.iframeProtocol.channelListen(
+      (mes: any) => {
+        switch (mes.type) {
+          case 'start': {
+            this.errors = [];
+            break;
+          }
+          case 'status': {
+            this.status = mes.status;
+            break;
+          }
+          case 'action': {
+            if (mes.action === 'show-error') {
+              const { title, path, message, line, column } = mes;
+              this.errors = [
+                ...this.errors,
+                { title, path, message, line, column },
+              ];
             }
-
-            this.updatePreview(this.sandboxInfo, true);
+            break;
           }
-          break;
-        }
-        case 'start': {
-          this.errors = [];
-          break;
-        }
-        case 'status': {
-          this.status = mes.status;
-          break;
-        }
-        case 'action': {
-          if (mes.action === 'show-error') {
-            const { title, path, message, line, column } = mes;
-            this.errors = [
-              ...this.errors,
-              { title, path, message, line, column },
-            ];
+          case 'state': {
+            this.bundlerState = mes.state;
+            break;
           }
-          break;
-        }
-        case 'state': {
-          this.bundlerState = mes.state;
-          break;
-        }
-        default: {
-          // Do nothing
         }
       }
-    });
+    );
+  }
+
+  cleanup() {
+    this.unsubscribeChannelListener();
+    this.unsubscribeGlobalListener();
+    this.iframeProtocol.cleanup();
   }
 
   updateOptions(options: ClientOptions) {
@@ -263,19 +270,11 @@ export class SandpackClient {
   }
 
   public dispatch(message: Object) {
-    // @ts-ignore We want to add the id, don't use Object.assign since that copies the message.
-    message.$id = this.id;
-    dispatch(message);
+    this.iframeProtocol.dispatch(message);
   }
 
   public listen(listener: (msg: any) => void): Function {
-    return listen((msg: any) => {
-      if (msg.$id !== this.id) {
-        return;
-      }
-
-      listener(msg);
-    });
+    return this.iframeProtocol.channelListen(listener);
   }
 
   /**
@@ -315,11 +314,11 @@ export class SandpackClient {
     [transpiler: string]: Object;
   }> =>
     new Promise(resolve => {
-      const listener = this.listen((message: any) => {
+      const unsubscribe = this.listen((message: any) => {
         if (message.type === 'transpiler-context') {
           resolve(message.data);
 
-          listener();
+          unsubscribe();
         }
       });
 

--- a/sandpack-client/src/file-resolver-protocol.ts
+++ b/sandpack-client/src/file-resolver-protocol.ts
@@ -1,0 +1,116 @@
+const generateId = () =>
+  // Such a random ID
+  Math.floor(Math.random() * 1000000 + Math.random() * 1000000);
+
+const getConstructorName = (x: any) => {
+  try {
+    return x.constructor.name;
+  } catch (e) {
+    return '';
+  }
+};
+
+export default class Protocol {
+  private outgoingMessages: Set<number> = new Set();
+  private internalId: number;
+  private isWorker: boolean;
+
+  constructor(
+    private type: string,
+    private handleMessage: (message: any) => any,
+    private target: Worker | Window
+  ) {
+    this.createConnection();
+    this.internalId = generateId();
+    this.isWorker = getConstructorName(target) === 'Worker';
+  }
+
+  getTypeId() {
+    return `p-${this.type}`;
+  }
+
+  createConnection() {
+    self.addEventListener('message', this._messageListener);
+  }
+
+  public dispose() {
+    self.removeEventListener('message', this._messageListener);
+  }
+
+  sendMessage<PromiseType>(data: any): Promise<PromiseType> {
+    return new Promise(resolve => {
+      const messageId = generateId();
+
+      const message = {
+        $originId: this.internalId,
+        $type: this.getTypeId(),
+        $data: data,
+        $id: messageId,
+      };
+
+      this.outgoingMessages.add(messageId);
+
+      const listenFunction = (e: MessageEvent) => {
+        const { data } = e;
+
+        if (
+          data.$type === this.getTypeId() &&
+          data.$id === messageId &&
+          data.$originId !== this.internalId
+        ) {
+          resolve(data.$data);
+
+          self.removeEventListener('message', listenFunction);
+        }
+      };
+
+      self.addEventListener('message', listenFunction);
+
+      this._postMessage(message);
+    });
+  }
+
+  private _messageListener = async (e: MessageEvent) => {
+    const { data } = e;
+
+    if (data.$type !== this.getTypeId()) {
+      return;
+    }
+
+    // We are getting a response to the message
+    if (this.outgoingMessages.has(data.$id)) {
+      return;
+    }
+
+    const result = await this.handleMessage(data.$data);
+
+    const returnMessage = {
+      $originId: this.internalId,
+      $type: this.getTypeId(),
+      $data: result,
+      $id: data.$id,
+    };
+
+    if (e.source) {
+      // @ts-ignore
+      e.source.postMessage(returnMessage, '*');
+    } else {
+      this._postMessage(returnMessage);
+    }
+  };
+
+  private _postMessage(m: any) {
+    if (
+      this.isWorker ||
+      // @ts-ignore Unknown to TS
+      (typeof DedicatedWorkerGlobalScope !== 'undefined' &&
+        // @ts-ignore Unknown to TS
+        this.target instanceof DedicatedWorkerGlobalScope)
+    ) {
+      // @ts-ignore
+      this.target.postMessage(m);
+    } else {
+      (this.target as Window).postMessage(m, '*');
+    }
+  }
+}

--- a/sandpack-client/src/iframe-protocol.ts
+++ b/sandpack-client/src/iframe-protocol.ts
@@ -1,0 +1,118 @@
+export class IFrameProtocol {
+  private frameWindow: Window | null;
+  private origin: string;
+
+  // React to messages from any iframe
+  private globalListeners: Record<number, Function> = {};
+  private globalListenersCount = 0;
+
+  // React to messages from the iframe owned by this instance
+  private channelListeners: Record<number, Function> = {};
+  private channelListenersCount = 0;
+
+  // Random number to identify this instance of the client when messages are coming from multiple iframes
+  readonly channelId: number = Math.floor(Math.random() * 1000000);
+
+  constructor(iframe: HTMLIFrameElement, origin: string) {
+    this.frameWindow = iframe.contentWindow;
+    this.origin = origin;
+    this.globalListeners = [];
+    this.channelListeners = [];
+
+    this.eventListener = this.eventListener.bind(this);
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('message', this.eventListener);
+    }
+  }
+
+  cleanup() {
+    window.removeEventListener('message', this.eventListener);
+    this.globalListeners = {};
+    this.channelListeners = {};
+    this.globalListenersCount = 0;
+    this.channelListenersCount = 0;
+  }
+
+  // Sends the channelId and triggers an iframeHandshake promise to resolve,
+  // so the iframe can start listening for messages (based on the id)
+  register() {
+    if (!this.frameWindow) {
+      return;
+    }
+
+    this.frameWindow.postMessage(
+      {
+        type: 'register-frame',
+        origin: document.location.origin,
+        id: this.channelId, // TODO: Rename in codesandbox-api to channelId
+      },
+      this.origin
+    );
+  }
+
+  // Messages are dispatched from the client directly to the instance iframe
+  dispatch(message: any) {
+    if (!this.frameWindow) {
+      return;
+    }
+
+    this.frameWindow.postMessage(
+      {
+        $id: this.channelId,
+        codesandbox: true,
+        ...message,
+      },
+      this.origin
+    );
+  }
+
+  // Add a listener that is called on any message coming from an iframe in the page
+  // This is needed for the `initialize` message which comes without a channelId
+  globalListen(listener: Function) {
+    if (typeof listener !== 'function') {
+      return () => {};
+    }
+
+    const listenerId = this.globalListenersCount;
+    this.globalListeners[listenerId] = listener;
+    this.globalListenersCount++;
+    return () => {
+      delete this.globalListeners[listenerId];
+    };
+  }
+
+  // Add a listener that is called on any message coming from an iframe with the instance channelId
+  // All other messages (eg: from other iframes) are ignored
+  channelListen(listener: Function) {
+    if (typeof listener !== 'function') {
+      return () => {};
+    }
+
+    const listenerId = this.channelListenersCount;
+    this.channelListeners[listenerId] = listener;
+    this.channelListenersCount++;
+    return () => {
+      delete this.channelListeners[listenerId];
+    };
+  }
+
+  // Handles message windows coming from iframes
+  private eventListener(message: MessageEvent) {
+    if (!message.data.codesandbox) {
+      return;
+    }
+
+    Object.values(this.globalListeners).forEach(listener =>
+      listener(message.data)
+    );
+
+    if (message.data.$id !== this.channelId) {
+      return;
+    }
+
+    Object.values(this.channelListeners).forEach(listener =>
+      listener(message.data)
+    );
+  }
+}

--- a/sandpack-client/yarn.lock
+++ b/sandpack-client/yarn.lock
@@ -282,11 +282,6 @@ clone@^1.0.0, clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-codesandbox-api@^0.0.32:
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/codesandbox-api/-/codesandbox-api-0.0.32.tgz#dd2a937687398a3288f6b6534b56a2d059edeaef"
-  integrity sha512-YMQDDW9AdkAAQij0yg+DjdACulkIgtnsOGam70zUP/tuGI5hM4pjaadXPU1BI/GrZHO2Df7Y/TSWcxwyz10PbQ==
-
 codesandbox-import-util-types@^1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/codesandbox-import-util-types/-/codesandbox-import-util-types-1.3.7.tgz#7a6097e248a75424d13b06b74368cd76bd2b3e10"

--- a/sandpack-react/package.json
+++ b/sandpack-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-smooshpack",
-  "version": "1.0.0-beta-4",
+  "version": "1.0.0-beta-5",
   "description": "",
   "keywords": [],
   "repository": {

--- a/sandpack-react/src/contexts/sandpack-context.tsx
+++ b/sandpack-react/src/contexts/sandpack-context.tsx
@@ -246,6 +246,10 @@ class SandpackProvider extends React.PureComponent<
     if (this.intersectionObserver) {
       this.intersectionObserver.disconnect();
     }
+
+    if (this.client) {
+      this.client.cleanup();
+    }
   }
 
   runSandpack = () => {

--- a/sandpack-react/yarn.lock
+++ b/sandpack-react/yarn.lock
@@ -3795,11 +3795,6 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codesandbox-api@^0.0.32:
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/codesandbox-api/-/codesandbox-api-0.0.32.tgz#dd2a937687398a3288f6b6534b56a2d059edeaef"
-  integrity sha512-YMQDDW9AdkAAQij0yg+DjdACulkIgtnsOGam70zUP/tuGI5hM4pjaadXPU1BI/GrZHO2Df7Y/TSWcxwyz10PbQ==
-
 codesandbox-import-util-types@^1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/codesandbox-import-util-types/-/codesandbox-import-util-types-1.3.7.tgz#7a6097e248a75424d13b06b74368cd76bd2b3e10"
@@ -9497,12 +9492,11 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-smooshpack@1.0.0-beta-4:
-  version "1.0.0-beta-4"
-  resolved "https://registry.yarnpkg.com/smooshpack/-/smooshpack-1.0.0-beta-4.tgz#b54b8a62a81b1653fa851ef7f2b956b7692a9efb"
-  integrity sha512-697y5A2e14RmYjA25CgN+A3RR7nIryomYXmVBeRwTyaD0IXdkziqS7kGt2dZHOjDXlqwlSqItObNezuD20jj/A==
+smooshpack@1.0.0-beta-5:
+  version "1.0.0-beta-5"
+  resolved "https://registry.yarnpkg.com/smooshpack/-/smooshpack-1.0.0-beta-5.tgz#f112b2ad68093884fda6170fdaf91ecb051a2bd2"
+  integrity sha512-DszOdnRY90R8A6y8DCL96f9BE6bEaMBRWJoaL5I3XfvbxxTi6PdPGfgFLp77uWlx3rHDLNIe2Uvnib1nRRFROA==
   dependencies:
-    codesandbox-api "^0.0.32"
     codesandbox-import-utils "^1.2.3"
     lodash.isequal "^4.5.0"
 


### PR DESCRIPTION
Simplifies the listen/dispatch flows:
- no need to wait for iframe handshake, global listener can wait for the initialized message
- the dispatch does not trigger the listeners from the sandpack-client (eg: compile)
- added some cleanup code so no listeners are left as components are mounted/unmounted
- class implementation ensures no code is executed before it is needed (eg: before sandpack is running)

closes #12 