### PR TITLE
error screen details and small fixes

### DIFF
--- a/sandpack-client/src/file-resolver-protocol.ts
+++ b/sandpack-client/src/file-resolver-protocol.ts
@@ -1,3 +1,10 @@
+/**
+ * This file is a copy of the resolver from the `codesandbox-api` package.
+ * We wanted to avoid to reference codesandbox-api because of the code that runs on load in the package.
+ * The plan is to take some time and refactor codesandbox-api into what it was supposed to be in the first place,
+ * an abstraction over the actions that can be dispatched between the bundler and the iframe.
+ */
+
 const generateId = () =>
   // Such a random ID
   Math.floor(Math.random() * 1000000 + Math.random() * 1000000);

--- a/sandpack-client/src/types.ts
+++ b/sandpack-client/src/types.ts
@@ -27,12 +27,20 @@ export interface ModuleSource {
   sourceMap: unknown | undefined;
 }
 
-export interface ModuleError {
-  title: string;
-  message: string;
-  path: string;
-  line: number;
-  column: number;
+export interface ErrorStackFrame {
+  columnNumber: number;
+  fileName: string;
+  functionName: string;
+  lineNumber: number;
+  _originalColumnNumber: number;
+  _originalFileName: string;
+  _originalFunctionName: string;
+  _originalLineNumber: number;
+  _originalScriptCode: Array<{
+    lineNumber: number;
+    content: string;
+    highlight: boolean;
+  }>;
 }
 
 export interface TranspiledModule {
@@ -73,6 +81,25 @@ export type UnsubscribeFunction = () => void;
 export type Listen = (listener: ListenerFunction) => UnsubscribeFunction;
 export type Dispatch = (msg: SandpackMessage) => void;
 
+export interface SandpackError {
+  message: string;
+  line?: number;
+  column?: number;
+  path?: string;
+  title?: string;
+}
+
+export interface SandpackErrorMessage {
+  title: string;
+  path: string;
+  message: string;
+  line: number;
+  column: number;
+  payload: {
+    frames?: ErrorStackFrame[];
+  };
+}
+
 export interface BaseSandpackMessage {
   type: string;
   $id?: number;
@@ -99,15 +126,10 @@ export type SandpackMessage = BaseSandpackMessage &
     | {
         type: "success";
       }
-    | {
+    | ({
         type: "action";
         action: "show-error";
-        title: string;
-        path: string;
-        message: string;
-        line: number;
-        column: number;
-      }
+      } & SandpackErrorMessage)
     | {
         type: "action";
         action: "notification";
@@ -145,6 +167,7 @@ export type SandpackMessage = BaseSandpackMessage &
         showErrorScreen: boolean;
         showLoadingScreen: boolean;
         skipEval: boolean;
+        clearConsoleDisabled?: boolean;
       }
     | {
         type: "refresh";

--- a/sandpack-client/src/utils.ts
+++ b/sandpack-client/src/utils.ts
@@ -1,4 +1,10 @@
-import type { SandpackBundlerFiles, Dependencies } from "./types";
+import type {
+  SandpackBundlerFiles,
+  Dependencies,
+  SandpackErrorMessage,
+  SandpackError,
+  ErrorStackFrame,
+} from "./types";
 
 export function createPackageJSON(
   dependencies: Dependencies = {},
@@ -41,4 +47,95 @@ export function addPackageJSONIfNeeded(
   }
 
   return newFiles;
+}
+
+export function extractErrorDetails(msg: SandpackErrorMessage): SandpackError {
+  if (msg.title === "SyntaxError") {
+    const { title, path, message, line, column } = msg;
+    return { title, path, message, line, column };
+  }
+
+  const relevantStackFrame = getRelevantStackFrame(msg.payload.frames);
+  if (!relevantStackFrame) {
+    return { message: msg.message };
+  }
+
+  const errorInCode = getErrorInOriginalCode(relevantStackFrame);
+  const errorLocation = getErrorLocation(relevantStackFrame);
+  const errorMessage = formatErrorMessage(
+    relevantStackFrame._originalFileName,
+    msg.message,
+    errorLocation,
+    errorInCode
+  );
+
+  return {
+    message: errorMessage,
+    title: msg.title,
+    path: relevantStackFrame._originalFileName,
+    line: relevantStackFrame._originalLineNumber,
+    column: relevantStackFrame._originalColumnNumber,
+  };
+}
+
+function getRelevantStackFrame(frames?: ErrorStackFrame[]) {
+  if (!frames) {
+    return;
+  }
+
+  return frames.find((frame) => !!frame._originalFileName);
+}
+
+function getErrorLocation(errorFrame: ErrorStackFrame) {
+  return errorFrame
+    ? ` (${errorFrame._originalLineNumber}:${errorFrame._originalColumnNumber})`
+    : ``;
+}
+
+function getErrorInOriginalCode(errorFrame: ErrorStackFrame) {
+  const lastScriptLine =
+    errorFrame._originalScriptCode[errorFrame._originalScriptCode.length - 1];
+  const numberOfLineNumberCharacters = lastScriptLine.lineNumber.toString()
+    .length;
+
+  const leadingCharacterOffset = 2;
+  const barSeparatorCharacterOffset = 3;
+  const extraLineLeadingSpaces =
+    leadingCharacterOffset +
+    numberOfLineNumberCharacters +
+    barSeparatorCharacterOffset +
+    errorFrame._originalColumnNumber;
+
+  return errorFrame._originalScriptCode.reduce((result, scriptLine) => {
+    const leadingChar = scriptLine.highlight ? ">" : " ";
+    const lineNumber =
+      scriptLine.lineNumber.toString().length === numberOfLineNumberCharacters
+        ? `${scriptLine.lineNumber}`
+        : ` ${scriptLine.lineNumber}`;
+
+    const extraLine = scriptLine.highlight
+      ? "\n" + " ".repeat(extraLineLeadingSpaces) + "^"
+      : "";
+
+    return (
+      result + // accumulator
+      "\n" +
+      leadingChar + // > or " "
+      " " +
+      lineNumber + // line number on equal number of characters
+      " | " +
+      scriptLine.content + // code
+      extraLine // line under the highlighed line to show the column index
+    );
+  }, "");
+}
+
+function formatErrorMessage(
+  filePath: string,
+  message: string,
+  location: string,
+  errorInCode: string
+) {
+  return `${filePath}: ${message}${location}
+${errorInCode}`;
 }

--- a/sandpack-react/src/common/LoadingOverlay.tsx
+++ b/sandpack-react/src/common/LoadingOverlay.tsx
@@ -9,7 +9,6 @@ export const LoadingOverlay: React.FC = () => {
   const loadingOverlayState = useLoadingOverlayState();
   const c = useClasser("sp");
 
-  console.log(loadingOverlayState);
   if (loadingOverlayState === "hidden") {
     return null;
   }

--- a/sandpack-react/src/common/LoadingOverlay.tsx
+++ b/sandpack-react/src/common/LoadingOverlay.tsx
@@ -9,6 +9,7 @@ export const LoadingOverlay: React.FC = () => {
   const loadingOverlayState = useLoadingOverlayState();
   const c = useClasser("sp");
 
+  console.log(loadingOverlayState);
   if (loadingOverlayState === "hidden") {
     return null;
   }

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -196,12 +196,12 @@ class SandpackProvider extends React.PureComponent<
       };
 
       this.intersectionObserver = new IntersectionObserver((entries) => {
-        if (
-          entries[0]?.intersectionRatio > 0 &&
-          this.state.sandpackStatus === "initial"
-        ) {
+        if (entries[0]?.intersectionRatio > 0) {
           // Delay a cycle so all hooks register the refs for the sub-components (open in csb, loading, error overlay)
-          setTimeout(() => this.runSandpack());
+          setTimeout(() => {
+            this.intersectionObserver?.unobserve(this.lazyAnchorRef.current!);
+            this.runSandpack();
+          });
         }
       }, options);
 

--- a/sandpack-react/src/hooks/useErrorMessage.ts
+++ b/sandpack-react/src/hooks/useErrorMessage.ts
@@ -4,22 +4,11 @@ import { useSandpack } from "./useSandpack";
 
 export const useErrorMessage = (): string | null => {
   const { sandpack } = useSandpack();
+  const { error } = sandpack;
 
   React.useEffect(() => {
     sandpack.errorScreenRegisteredRef.current = true;
   }, []);
 
-  const { error } = sandpack;
-  if (!error) {
-    return null;
-  }
-
-  if (error.title === "SyntaxError") {
-    return error.message ?? null;
-  }
-
-  const errorLocation = error.line ? ` (${error.line}:${error.column})` : ``;
-  const errorMessage = `${error.path}: ${error.message}${errorLocation}`;
-
-  return errorMessage ?? null;
+  return error?.message ?? null;
 };

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -1,9 +1,9 @@
 import type {
   BundlerState,
-  ModuleError,
   Dispatch,
   Listen,
   SandpackBundlerFiles,
+  SandpackError,
 } from "@codesandbox/sandpack-client";
 
 export type SandpackContext = SandpackState & {
@@ -17,7 +17,7 @@ export interface SandpackState {
   activePath: string;
   startRoute?: string;
   editorState: EditorState;
-  error: Partial<ModuleError> | null;
+  error: SandpackError | null;
   files: SandpackBundlerFiles;
   status: SandpackStatus;
   runSandpack: () => void;


### PR DESCRIPTION
closes #32 - head tag replacing the original html head in the bundler on the first load
closes #14 - more information shown on runtime errors
closes #15 - option set to false in sandpack-client, can later be overwritten
closes #16 - inside the bundler