### PR TITLE
fix: style customization for playground component

### DIFF
--- a/sandpack-playground/src/App.tsx
+++ b/sandpack-playground/src/App.tsx
@@ -18,7 +18,10 @@ export const App: React.FC = () => {
           showTabs: true,
           showLineNumbers: true,
           showNavigator: true,
-          editorHeight: "calc(100vh - 5px)",
+          editorHeight: "100vh",
+          classes: {
+            "sp-layout": "no-border",
+          },
         }}
         template="react"
       />

--- a/sandpack-playground/src/index.html
+++ b/sandpack-playground/src/index.html
@@ -18,6 +18,11 @@
         body {
             line-height: 1;
         }
+
+        .no-border {
+            border: 0;
+            border-radius: 0;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
Made a quick example of how to update the style from the sandpack components. removed the border around the layout so 100vh on the editor is 100vh for the entire component