### PR TITLE
fix: loading timeout only counted after the client is instantiated

### DIFF
--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -41,7 +41,7 @@ export interface SandpackState {
   loadingScreenRegisteredRef: React.MutableRefObject<boolean>;
 }
 
-export type SandpackStatus = "initial" | "idle" | "running";
+export type SandpackStatus = "initial" | "idle" | "running" | "timeout";
 export type EditorState = "pristine" | "dirty";
 
 export interface SandboxTemplate {


### PR DESCRIPTION
Had to lift the timeout calculation to the sandpack context because the hook can be mounted before the client is instantiated (eg: when not using the autorun option)