### PR TITLE
feat(react): syntax inline error - CSB-735

### DIFF
--- a/sandpack-react/README.md
+++ b/sandpack-react/README.md
@@ -362,7 +362,7 @@ import {
   SandpackProvider,
   SandpackThemeProvider,
   SandpackPreview,
-} from '@codesandbox/sandpack-react';
+} from "@codesandbox/sandpack-react";
 
 const CustomSandpack = () => (
   <SandpackProvider>
@@ -438,12 +438,13 @@ of them comunicate with sandpack through the shared context.
 
 #### SandpackCodeEditor props
 
-| name            | type    | default                           | description                                                             |
-| --------------- | ------- | --------------------------------- | ----------------------------------------------------------------------- |
-| showTabs        | boolean | computed based on number of files | The FileTabs component is shown on top of the editor based on this flag |
-| showLineNumbers | boolean | false                             | Adds a column with line numbers on the left side of the code editor     |
-| showRunButton   | boolean | true                              | Shows a `Run` button when the sandpack is not set to `autorun`          |
-| wrapContent     | boolean | false                             | Wraps the code lines that don't fit horizontally                        |
+| name             | type    | default                           | description                                                                       |
+| ---------------- | ------- | --------------------------------- | --------------------------------------------------------------------------------- |
+| showTabs         | boolean | computed based on number of files | The FileTabs component is shown on top of the editor based on this flag           |
+| showLineNumbers  | boolean | false                             | Adds a column with line numbers on the left side of the code editor               |
+| showInlineErrors | boolean | false                             | Highlights the syntax errors and parse errors from the bundler in the code editor |
+| showRunButton    | boolean | true                              | Shows a `Run` button when the sandpack is not set to `autorun`                    |
+| wrapContent      | boolean | false                             | Wraps the code lines that don't fit horizontally                                  |
 
 #### SandpackPreview props
 

--- a/sandpack-react/src/components/CodeEditor/CodeEditor.stories.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeEditor.stories.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import { SandpackProvider } from "../../contexts/sandpackContext";
 import { SandpackThemeProvider } from "../../contexts/themeContext";
+import { SandpackPreview } from "../Preview";
 
 import type { CodeEditorProps } from "./index";
 import { SandpackCodeEditor } from "./index";
@@ -25,6 +26,15 @@ export const Component: Story<CodeEditorProps> = (args) => (
   >
     <SandpackThemeProvider>
       <SandpackCodeEditor {...args} />
+    </SandpackThemeProvider>
+  </SandpackProvider>
+);
+
+export const InlineError: React.FC = () => (
+  <SandpackProvider template="react">
+    <SandpackThemeProvider>
+      <SandpackCodeEditor showInlineErrors showLineNumbers />
+      <SandpackPreview />
     </SandpackThemeProvider>
   </SandpackProvider>
 );

--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -197,48 +197,48 @@ export const CodeMirror: React.FC<CodeMirrorProps> = ({
 
   React.useEffect(
     function messageToInlineError() {
-      if (showInlineErrors) {
-        const unsubscribe = listen((message) => {
-          const view = cmView.current;
+      if (!showInlineErrors) return () => null;
 
-          if (message.type === "success") {
-            view?.dispatch({
-              // Pass message to clean up inline error
-              annotations: [
-                ({
-                  type: "clean-error",
-                  value: null,
-                } as unknown) as Annotation<unknown>,
-              ],
+      const unsubscribe = listen((message) => {
+        const view = cmView.current;
 
-              // Trigger a doc change to remove inline error
-              changes: {
-                from: 0,
-                to: view.state.doc.length,
-                insert: view.state.doc,
-              },
-              selection: view.state.selection,
-            });
-          }
+        if (message.type === "success") {
+          view?.dispatch({
+            // Pass message to clean up inline error
+            annotations: [
+              ({
+                type: "clean-error",
+                value: null,
+              } as unknown) as Annotation<unknown>,
+            ],
 
-          if (
-            message.type === "action" &&
-            message.action === "show-error" &&
-            "line" in message
-          ) {
-            view?.dispatch({
-              annotations: [
-                ({
-                  type: "error",
-                  value: message.line,
-                } as unknown) as Annotation<unknown>,
-              ],
-            });
-          }
-        });
+            // Trigger a doc change to remove inline error
+            changes: {
+              from: 0,
+              to: view.state.doc.length,
+              insert: view.state.doc,
+            },
+            selection: view.state.selection,
+          });
+        }
 
-        return () => unsubscribe();
-      }
+        if (
+          message.type === "action" &&
+          message.action === "show-error" &&
+          "line" in message
+        ) {
+          view?.dispatch({
+            annotations: [
+              ({
+                type: "error",
+                value: message.line,
+              } as unknown) as Annotation<unknown>,
+            ],
+          });
+        }
+      });
+
+      return () => unsubscribe();
     },
     [listen, showInlineErrors]
   );

--- a/sandpack-react/src/components/CodeEditor/highlightInlineError.ts
+++ b/sandpack-react/src/components/CodeEditor/highlightInlineError.ts
@@ -26,31 +26,26 @@ const activeLineHighlighter = ViewPlugin.fromClass(
           annotations: Array<{ type: string }>;
         }
 
-        console.log(trans);
-
-        return ((trans as unknown) as Annotations).annotations?.forEach(
-          (element) => {
-            if (element.type === "error") {
-              message = element;
-            }
-
-            if (element.type === "clean-error") {
-              message = element;
-            }
+        ((trans as unknown) as Annotations).annotations?.forEach((element) => {
+          if (element.type === "error") {
+            message = element;
           }
-        );
+
+          if (element.type === "clean-error") {
+            message = element;
+          }
+        });
       });
 
       if (message !== null) {
-        this.decorations = this.getDeco(update.view, message);
+        this.decorations = this.getDecoration(update.view, message);
       }
     }
 
-    getDeco(
+    getDecoration(
       view: EditorView,
       message: { type: "clean-error" } | { type: "error"; value: number } | null
     ) {
-      console.log(message);
       if (message === null || message.type === "clean-error") {
         return Decoration.none;
       }

--- a/sandpack-react/src/components/CodeEditor/highlightInlineError.ts
+++ b/sandpack-react/src/components/CodeEditor/highlightInlineError.ts
@@ -1,0 +1,76 @@
+import type { Extension } from "@codemirror/state";
+import type { DecorationSet, EditorView, ViewUpdate } from "@codemirror/view";
+import { Decoration, ViewPlugin } from "@codemirror/view";
+
+export function highlightInlineError(): Extension {
+  return activeLineHighlighter;
+}
+
+const lineDeco = Decoration.line({ attributes: { class: "cm-errorLine" } });
+
+const activeLineHighlighter = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor() {
+      this.decorations = Decoration.none;
+    }
+
+    update(update: ViewUpdate) {
+      let message = null;
+
+      update.transactions.forEach((trans) => {
+        // Overlap the types, it seems the original
+        // doesn't match what it really is.
+        interface Annotations {
+          annotations: Array<{ type: string }>;
+        }
+
+        console.log(trans);
+
+        return ((trans as unknown) as Annotations).annotations?.forEach(
+          (element) => {
+            if (element.type === "error") {
+              message = element;
+            }
+
+            if (element.type === "clean-error") {
+              message = element;
+            }
+          }
+        );
+      });
+
+      if (message !== null) {
+        this.decorations = this.getDeco(update.view, message);
+      }
+    }
+
+    getDeco(
+      view: EditorView,
+      message: { type: "clean-error" } | { type: "error"; value: number } | null
+    ) {
+      console.log(message);
+      if (message === null || message.type === "clean-error") {
+        return Decoration.none;
+      }
+
+      if (message.type === "error") {
+        const doc = (view.state.doc as unknown) as { text: string[] };
+        const position = doc.text.reduce((acc, curr, i) => {
+          if (i < message.value - 1) {
+            return acc + curr.length + 1;
+          }
+          return acc;
+        }, 0);
+
+        return Decoration.set([lineDeco.range(position)]);
+      }
+
+      return Decoration.none;
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  }
+);

--- a/sandpack-react/src/components/CodeEditor/highlightInlineError.ts
+++ b/sandpack-react/src/components/CodeEditor/highlightInlineError.ts
@@ -52,7 +52,10 @@ const activeLineHighlighter = ViewPlugin.fromClass(
 
       if (message.type === "error") {
         const doc = (view.state.doc as unknown) as { text: string[] };
+
+        // It calculates the position for a given line
         const position = doc.text.reduce((acc, curr, i) => {
+          // -1 is to fix the array index
           if (i < message.value - 1) {
             return acc + curr.length + 1;
           }

--- a/sandpack-react/src/components/CodeEditor/index.tsx
+++ b/sandpack-react/src/components/CodeEditor/index.tsx
@@ -13,6 +13,7 @@ export interface CodeEditorProps {
   customStyle?: React.CSSProperties;
   showTabs?: boolean;
   showLineNumbers?: boolean;
+  showInlineErrors?: boolean;
   showRunButton?: boolean;
   wrapContent?: boolean;
 }
@@ -23,6 +24,7 @@ export const SandpackCodeEditor: React.FC<CodeEditorProps> = ({
   customStyle,
   showTabs,
   showLineNumbers = false,
+  showInlineErrors = false,
   showRunButton = true,
   wrapContent = false,
 }) => {
@@ -48,6 +50,7 @@ export const SandpackCodeEditor: React.FC<CodeEditorProps> = ({
           editorState={editorState}
           filePath={activePath}
           onCodeUpdate={handleCodeUpdate}
+          showInlineErrors={showInlineErrors}
           showLineNumbers={showLineNumbers}
           wrapContent={wrapContent}
         />

--- a/sandpack-react/src/components/CodeEditor/utils.ts
+++ b/sandpack-react/src/components/CodeEditor/utils.ts
@@ -27,6 +27,10 @@ export const getEditorTheme = (theme: SandpackTheme): Extension =>
       backgroundColor: hexToCSSRGBa(theme.palette.activeBackground, 0.5),
     },
 
+    ".cm-errorLine": {
+      backgroundColor: hexToCSSRGBa(theme.palette.errorBackground, 0.2),
+    },
+
     ".cm-matchingBracket, .cm-nonmatchingBracket": {
       color: "inherit",
       background: theme.palette.activeBackground,

--- a/sandpack-react/src/presets/Sandpack.stories.tsx
+++ b/sandpack-react/src/presets/Sandpack.stories.tsx
@@ -44,6 +44,7 @@ export const ReactEditor: Story<SandpackProps> = (args) => (
     }}
     options={{
       showLineNumbers: true,
+      showInlineErrors: true,
     }}
     template="react"
   />

--- a/sandpack-react/src/presets/Sandpack.tsx
+++ b/sandpack-react/src/presets/Sandpack.tsx
@@ -32,6 +32,7 @@ export interface SandpackProps {
 
     showNavigator?: boolean;
     showLineNumbers?: boolean;
+    showInlineErrors?: boolean;
     showTabs?: boolean;
     wrapContent?: boolean;
 
@@ -65,6 +66,7 @@ export const Sandpack: React.FC<SandpackProps> = (props) => {
   const codeEditorOptions: CodeEditorProps = {
     showTabs: props.options?.showTabs,
     showLineNumbers: props.options?.showLineNumbers,
+    showInlineErrors: props.options?.showInlineErrors,
     wrapContent: props.options?.wrapContent,
   };
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/4838076/125803444-744736d3-7f94-4c8a-b164-c6aed1f108ae.mov

It introduces a new prop `showInlineErrors` which basically consumes the error logs from the bundler and highlights it in the Codemirror using the class name`cm-errorLine`, which will allow customization on top of this feature.

How it works:
- Basically, a new plugin was created to handle the decoration in the editor, and this plugin listen to changes from the editor;
- Then, a new sandpack listener was introduced to listen to the bundler error and pass these messages to the editor through `annotations` changes;
- Once all errors are solved, the listener triggers a new code change (with the same input and same selection values), just to clean up the decoration - kind of a hack, but it works properly without overengineering anything.

In order to achieve our goal, it's still missing the bundler error customization, but I'm not how to proceed with it and even if we should.

Reference https://github.com/codemirror/view/blob/main/src/active-line.ts