### PR TITLE
feat(usesandpack): reset-file and reset-all-files CSB-829

### DIFF
--- a/sandpack-react/README.md
+++ b/sandpack-react/README.md
@@ -543,6 +543,22 @@ const CustomRefreshButton = () => {
 };
 ```
 
+#### All methods
+
+Plus, `useSandpack` exposes a bunch of methods that you can use to manage the current state of the Sandpack instance:
+
+| Method          | Description                                 |
+| --------------- | ------------------------------------------- |
+| `closeFile`     | Close the given path in the editor          |
+| `deleteFile`    | Delete the given path in the editor         |
+| `dispatch`      | Sends a message to the bundler              |
+| `listen`        | Listens for messages from the bundler       |
+| `openFile`      | Open the given path in the editor           |
+| `resetAllFiles` | Reset all files for all paths               |
+| `resetFile`     | Reset the code for a given path             |
+| `setActiveFile` | Set as active the file for a given path     |
+| `updateFile`    | Give a path and a code, it updates the file |
+
 #### useActiveCode, useCodeSandboxLink, useSandpackNavigation
 
 Some of the common functionalities of sandpack are also extracted into

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -518,6 +518,20 @@ class SandpackProvider extends React.PureComponent<
     }
   };
 
+  resetFile = (path: string): void => {
+    const { files } = getSandpackStateFromProps(this.props);
+
+    this.setState((prevState) => ({
+      files: { ...prevState.files, [path]: files[path] },
+    }));
+  };
+
+  resetAllFiles = (): void => {
+    const { files } = getSandpackStateFromProps(this.props);
+
+    this.setState({ files });
+  };
+
   _getSandpackState = (): SandpackContext => {
     const {
       files,
@@ -541,21 +555,23 @@ class SandpackProvider extends React.PureComponent<
       bundlerState,
       status: sandpackStatus,
       editorState,
-      setActiveFile: this.setActiveFile,
-      openFile: this.openFile,
       closeFile: this.closeFile,
+      deleteFile: this.deleteFile,
+      dispatch: this.dispatchMessage,
+      errorScreenRegisteredRef: this.errorScreenRegistered,
+      lazyAnchorRef: this.lazyAnchorRef,
+      listen: this.addListener,
+      loadingScreenRegisteredRef: this.loadingScreenRegistered,
+      openFile: this.openFile,
+      openInCSBRegisteredRef: this.openInCSBRegistered,
+      registerBundler: this.registerBundler,
+      resetAllFiles: this.resetAllFiles,
+      resetFile: this.resetFile,
+      runSandpack: this.runSandpack,
+      setActiveFile: this.setActiveFile,
+      unregisterBundler: this.unregisterBundler,
       updateCurrentFile: this.updateCurrentFile,
       updateFile: this.updateFile,
-      runSandpack: this.runSandpack,
-      registerBundler: this.registerBundler,
-      unregisterBundler: this.unregisterBundler,
-      dispatch: this.dispatchMessage,
-      listen: this.addListener,
-      deleteFile: this.deleteFile,
-      lazyAnchorRef: this.lazyAnchorRef,
-      errorScreenRegisteredRef: this.errorScreenRegistered,
-      openInCSBRegisteredRef: this.openInCSBRegistered,
-      loadingScreenRegisteredRef: this.loadingScreenRegistered,
     };
   };
 

--- a/sandpack-react/src/presets/Sandpack.stories.tsx
+++ b/sandpack-react/src/presets/Sandpack.stories.tsx
@@ -1,6 +1,10 @@
 import type { Story } from "@storybook/react";
 import React from "react";
 
+import { SandpackProvider, SandpackLayout, SandpackStack } from "..";
+import { SandpackCodeEditor } from "../components/CodeEditor";
+import { SandpackPreview } from "../components/Preview";
+import { useSandpack } from "../hooks/useSandpack";
 import { codesandboxDarkTheme } from "../themes";
 
 import type { SandpackProps } from "./Sandpack";
@@ -328,4 +332,94 @@ export const RunnableComponent = (): React.ReactElement => (
     }}
     template="react"
   />
+);
+
+const ResetButton = () => {
+  const { sandpack } = useSandpack();
+
+  return (
+    <button
+      className="sp-tab-button"
+      onClick={sandpack.resetAllFiles}
+      style={{
+        background: "none",
+        border: 0,
+        position: "absolute",
+        right: "1em",
+      }}
+    >
+      Reset all file
+    </button>
+  );
+};
+
+const ResetCurrentFileButton = () => {
+  const { sandpack } = useSandpack();
+
+  return (
+    <button
+      className="sp-tab-button"
+      onClick={() => sandpack.resetFile(sandpack.activePath)}
+      style={{
+        background: "none",
+        border: 0,
+        position: "absolute",
+        right: "1em",
+      }}
+    >
+      Reset current files
+    </button>
+  );
+};
+
+export const WithResetButton: React.FC = () => (
+  <>
+    <SandpackProvider
+      customSetup={{
+        files: {
+          "/App.js": reactCode,
+          "/button.js": buttonCode,
+          "/link.js": linkCode,
+        },
+      }}
+      template="react"
+    >
+      <SandpackLayout>
+        <div
+          className="sp-stack"
+          style={{ position: "relative", width: "100%" }}
+        >
+          <SandpackCodeEditor />
+          <ResetButton />
+        </div>
+        <SandpackStack>
+          <SandpackPreview />
+        </SandpackStack>
+      </SandpackLayout>
+    </SandpackProvider>
+
+    <SandpackProvider
+      customSetup={{
+        files: {
+          "/App.js": reactCode,
+          "/button.js": buttonCode,
+          "/link.js": linkCode,
+        },
+      }}
+      template="react"
+    >
+      <SandpackLayout>
+        <div
+          className="sp-stack"
+          style={{ position: "relative", width: "100%" }}
+        >
+          <SandpackCodeEditor />
+          <ResetCurrentFileButton />
+        </div>
+        <SandpackStack>
+          <SandpackPreview />
+        </SandpackStack>
+      </SandpackLayout>
+    </SandpackProvider>
+  </>
 );

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -43,6 +43,8 @@ export interface SandpackState {
   closeFile: (path: string) => void;
   deleteFile: (path: string) => void;
   setActiveFile: (path: string) => void;
+  resetFile: (path: string) => void;
+  resetAllFiles: () => void;
 
   // Element refs
   // Different components inside the SandpackProvider might register certain elements of interest for sandpack


### PR DESCRIPTION
It implements the ability to reset the files for the original values from `props`. The following methods were added to the context:
| Method | Description |
| - | - |
| `resetAllFiles` | Reset all files for all paths               |
| `resetFile`     | Reset the code for a given path             |

CSB-829