### PR TITLE
Codeviewer the initial placeholder

### DIFF
--- a/sandpack-react/src/styles/index.css
+++ b/sandpack-react/src/styles/index.css
@@ -101,6 +101,7 @@
 
 .sp-pre-placeholder {
   margin: 0;
+  display: block;
   padding: 0 var(--sp-space-3);
   font-family: var(--sp-font-mono);
   font-size: var(--sp-font-size);
@@ -120,10 +121,6 @@
   margin: 0;
   outline: none;
   height: 100%;
-}
-
-.sp-cm code {
-  display: block;
 }
 
 .sp-cm:focus-visible {


### PR DESCRIPTION
As the tag `code` is an inline element, it doesn't support padding for multiple lines. Applying the block style the padding works as expected.

<img width="494" alt="Screenshot 2021-10-14 at 15 53 20" src="https://user-images.githubusercontent.com/4838076/137342812-705d0272-2265-420d-a3cb-1a476fa661f3.png">
