### PR TITLE
feat(template): add react typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# IDEs
+.idea

--- a/sandpack-client/src/client.ts
+++ b/sandpack-client/src/client.ts
@@ -237,8 +237,8 @@ export class SandpackClient {
     let packageJSON = JSON.parse(
       createPackageJSON(
         this.sandboxInfo.dependencies,
-        this.sandboxInfo.entry,
-        this.sandboxInfo.devDependencies
+        this.sandboxInfo.devDependencies,
+        this.sandboxInfo.entry
       )
     );
     try {

--- a/sandpack-client/src/client.ts
+++ b/sandpack-client/src/client.ts
@@ -67,6 +67,7 @@ export interface ClientOptions {
 export interface SandboxInfo {
   files: SandpackBundlerFiles;
   dependencies?: Dependencies;
+  devDependencies?: Dependencies;
   entry?: string;
   /**
    * What template we use, if not defined we infer the template from the dependencies or files.
@@ -234,7 +235,11 @@ export class SandpackClient {
     );
 
     let packageJSON = JSON.parse(
-      createPackageJSON(this.sandboxInfo.dependencies, this.sandboxInfo.entry)
+      createPackageJSON(
+        this.sandboxInfo.dependencies,
+        this.sandboxInfo.entry,
+        this.sandboxInfo.devDependencies
+      )
     );
     try {
       packageJSON = JSON.parse(files["/package.json"].code);
@@ -262,8 +267,8 @@ export class SandpackClient {
       modules,
       externalResources: [],
       hasFileResolver: Boolean(this.options.fileResolver),
-      disableDependencyPreprocessing: this.sandboxInfo
-        .disableDependencyPreprocessing,
+      disableDependencyPreprocessing:
+        this.sandboxInfo.disableDependencyPreprocessing,
       template:
         this.sandboxInfo.template ||
         getTemplate(packageJSON, normalizedModules),
@@ -342,6 +347,7 @@ export class SandpackClient {
       return addPackageJSONIfNeeded(
         sandboxInfo.files,
         sandboxInfo.dependencies,
+        sandboxInfo.devDependencies,
         sandboxInfo.entry
       );
     }

--- a/sandpack-client/src/utils.ts
+++ b/sandpack-client/src/utils.ts
@@ -8,22 +8,24 @@ import type {
 
 export function createPackageJSON(
   dependencies: Dependencies = {},
-  entry = "/index.js"
+  entry = "/index.js",
+  devDependencies?: Dependencies
 ): string {
-  return JSON.stringify(
-    {
-      name: "sandpack-project",
-      main: entry,
-      dependencies,
-    },
-    null,
-    2
-  );
+  const packageJsonContent: Record<string, string | Dependencies> = {
+    name: "sandpack-project",
+    main: entry,
+    dependencies,
+  };
+  if (devDependencies && Object.keys(devDependencies).length) {
+    packageJsonContent["devDependencies"] = devDependencies;
+  }
+  return JSON.stringify(packageJsonContent, null, 2);
 }
 
 export function addPackageJSONIfNeeded(
   files: SandpackBundlerFiles,
   dependencies?: Dependencies,
+  devDependencies?: Dependencies,
   entry?: string
 ): SandpackBundlerFiles {
   const newFiles = { ...files };
@@ -42,7 +44,7 @@ export function addPackageJSONIfNeeded(
     }
 
     newFiles["/package.json"] = {
-      code: createPackageJSON(dependencies, entry),
+      code: createPackageJSON(dependencies, entry, devDependencies),
     };
   }
 
@@ -95,8 +97,8 @@ function getErrorLocation(errorFrame: ErrorStackFrame) {
 function getErrorInOriginalCode(errorFrame: ErrorStackFrame) {
   const lastScriptLine =
     errorFrame._originalScriptCode[errorFrame._originalScriptCode.length - 1];
-  const numberOfLineNumberCharacters = lastScriptLine.lineNumber.toString()
-    .length;
+  const numberOfLineNumberCharacters =
+    lastScriptLine.lineNumber.toString().length;
 
   const leadingCharacterOffset = 2;
   const barSeparatorCharacterOffset = 3;

--- a/sandpack-client/src/utils.ts
+++ b/sandpack-client/src/utils.ts
@@ -8,18 +8,19 @@ import type {
 
 export function createPackageJSON(
   dependencies: Dependencies = {},
-  entry = "/index.js",
-  devDependencies?: Dependencies
+  devDependencies: Dependencies = {},
+  entry = "/index.js"
 ): string {
-  const packageJsonContent: Record<string, string | Dependencies> = {
-    name: "sandpack-project",
-    main: entry,
-    dependencies,
-  };
-  if (devDependencies && Object.keys(devDependencies).length) {
-    packageJsonContent["devDependencies"] = devDependencies;
-  }
-  return JSON.stringify(packageJsonContent, null, 2);
+  return JSON.stringify(
+    {
+      name: "sandpack-project",
+      main: entry,
+      dependencies,
+      devDependencies,
+    },
+    null,
+    2
+  );
 }
 
 export function addPackageJSONIfNeeded(
@@ -44,7 +45,7 @@ export function addPackageJSONIfNeeded(
     }
 
     newFiles["/package.json"] = {
-      code: createPackageJSON(dependencies, entry, devDependencies),
+      code: createPackageJSON(dependencies, devDependencies, entry),
     };
   }
 

--- a/sandpack-react/src/presets/Sandpack.stories.tsx
+++ b/sandpack-react/src/presets/Sandpack.stories.tsx
@@ -89,7 +89,7 @@ export const ReactTypescriptEditor: Story<SandpackProps> = (args) => (
       showLineNumbers: true,
       showInlineErrors: true,
     }}
-    template="react-typescript"
+    template="react-ts"
   />
 );
 

--- a/sandpack-react/src/presets/Sandpack.stories.tsx
+++ b/sandpack-react/src/presets/Sandpack.stories.tsx
@@ -81,9 +81,9 @@ export const ReactTypescriptEditor: Story<SandpackProps> = (args) => (
   <Sandpack
     {...args}
     files={{
-      "/App.tsx": reactCodeTsx,
-      "/button.tsx": buttonCodeTsx,
-      "/link.tsx": linkCodeTsx,
+      "/src/App.tsx": reactCodeTsx,
+      "/src/button.tsx": buttonCodeTsx,
+      "/src/link.tsx": linkCodeTsx,
     }}
     options={{
       showLineNumbers: true,

--- a/sandpack-react/src/presets/Sandpack.stories.tsx
+++ b/sandpack-react/src/presets/Sandpack.stories.tsx
@@ -54,6 +54,45 @@ export const ReactEditor: Story<SandpackProps> = (args) => (
   />
 );
 
+const reactCodeTsx = `import Button from './button';
+import Link from './link';
+
+export default function App(): JSX.Element {
+  return (
+    <div>
+      <h1>Hello World</h1>
+      <Button />
+      <Link />
+    </div>
+  )
+}
+`;
+
+const buttonCodeTsx = `export default function Button(): JSX.Element {
+  return <button>Click me</button>
+}
+`;
+
+const linkCodeTsx = `export default function Link(): JSX.Element {
+  return <a href="https://www.example.com" target="_blank">Click Here</a>
+}`;
+
+export const ReactTypescriptEditor: Story<SandpackProps> = (args) => (
+  <Sandpack
+    {...args}
+    files={{
+      "/App.tsx": reactCodeTsx,
+      "/button.tsx": buttonCodeTsx,
+      "/link.tsx": linkCodeTsx,
+    }}
+    options={{
+      showLineNumbers: true,
+      showInlineErrors: true,
+    }}
+    template="react-typescript"
+  />
+);
+
 export const VueEditor: Story<SandpackProps> = (args) => (
   <Sandpack {...args} template="vue" theme="aqua-blue" />
 );

--- a/sandpack-react/src/templates/index.tsx
+++ b/sandpack-react/src/templates/index.tsx
@@ -12,7 +12,7 @@ export const SANDBOX_TEMPLATES: Record<
   SandboxTemplate
 > = {
   react: REACT_TEMPLATE,
-  "react-typescript": REACT_TYPESCRIPT_TEMPLATE,
+  "react-ts": REACT_TYPESCRIPT_TEMPLATE,
   vue: VUE_TEMPLATE,
   vanilla: VANILLA_TEMPLATE,
   vue3: VUE_TEMPLATE_3,

--- a/sandpack-react/src/templates/index.tsx
+++ b/sandpack-react/src/templates/index.tsx
@@ -5,12 +5,14 @@ import { REACT_TEMPLATE } from "./react";
 import { VANILLA_TEMPLATE } from "./vanilla";
 import { VUE_TEMPLATE } from "./vue";
 import { VUE_TEMPLATE_3 } from "./vue3";
+import { REACT_TYPESCRIPT_TEMPLATE } from "./react-typescript";
 
 export const SANDBOX_TEMPLATES: Record<
   SandpackPredefinedTemplate,
   SandboxTemplate
 > = {
   react: REACT_TEMPLATE,
+  "react-typescript": REACT_TYPESCRIPT_TEMPLATE,
   vue: VUE_TEMPLATE,
   vanilla: VANILLA_TEMPLATE,
   vue3: VUE_TEMPLATE_3,

--- a/sandpack-react/src/templates/react-typescript.ts
+++ b/sandpack-react/src/templates/react-typescript.ts
@@ -1,0 +1,86 @@
+import type { SandboxTemplate } from "../types";
+
+export const REACT_TYPESCRIPT_TEMPLATE: SandboxTemplate = {
+  files: {
+    "tsconfig.json": {
+      code: `{
+    "include": [
+        "./**/*"
+    ],
+    "compilerOptions": {
+        "strict": true,
+        "esModuleInterop": true,
+        "lib": [
+            "dom",
+            "es2015"
+        ],
+        "jsx": "react-jsx"
+    }
+}`,
+    },
+    "/App.tsx": {
+      code: `export default function App() {
+  return <h1>Hello World</h1>
+}
+`,
+    },
+    "/index.tsx": {
+      code: `import React, { StrictMode } from "react";
+import ReactDOM from "react-dom";
+import "./styles.css";
+
+import App from "./App";
+
+const rootElement = document.getElementById("root");
+ReactDOM.render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+  rootElement
+);`,
+    },
+    "/styles.css": {
+      code: `body {
+  font-family: sans-serif;
+  -webkit-font-smoothing: auto;
+  -moz-font-smoothing: auto;
+  -moz-osx-font-smoothing: grayscale;
+  font-smoothing: auto;
+  text-rendering: optimizeLegibility;
+  font-smooth: always;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+}
+
+h1 {
+  font-size: 1.5rem;
+}`,
+    },
+    "/public/index.html": {
+      code: `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>`,
+    },
+  },
+  dependencies: {
+    react: "^17.0.0",
+    "react-dom": "^17.0.0",
+    "react-scripts": "^4.0.0",
+  },
+  devDependencies: {
+    "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0",
+    typescript: "^4.0.0",
+  },
+  entry: "/index.tsx",
+  main: "/App.tsx",
+  environment: "create-react-app",
+};

--- a/sandpack-react/src/templates/react-typescript.ts
+++ b/sandpack-react/src/templates/react-typescript.ts
@@ -19,7 +19,7 @@ export const REACT_TYPESCRIPT_TEMPLATE: SandboxTemplate = {
 }`,
     },
     "/App.tsx": {
-      code: `export default function App() {
+      code: `export default function App(): JSX.Element {
   return <h1>Hello World</h1>
 }
 `,

--- a/sandpack-react/src/templates/react-typescript.ts
+++ b/sandpack-react/src/templates/react-typescript.ts
@@ -5,7 +5,7 @@ export const REACT_TYPESCRIPT_TEMPLATE: SandboxTemplate = {
     "tsconfig.json": {
       code: `{
     "include": [
-        "./**/*"
+        "./src/**/*"
     ],
     "compilerOptions": {
         "strict": true,
@@ -18,13 +18,13 @@ export const REACT_TYPESCRIPT_TEMPLATE: SandboxTemplate = {
     }
 }`,
     },
-    "/App.tsx": {
+    "/src/App.tsx": {
       code: `export default function App(): JSX.Element {
   return <h1>Hello World</h1>
 }
 `,
     },
-    "/index.tsx": {
+    "/src/index.tsx": {
       code: `import React, { StrictMode } from "react";
 import ReactDOM from "react-dom";
 import "./styles.css";
@@ -39,7 +39,7 @@ ReactDOM.render(
   rootElement
 );`,
     },
-    "/styles.css": {
+    "/src/styles.css": {
       code: `body {
   font-family: sans-serif;
   -webkit-font-smoothing: auto;
@@ -80,7 +80,7 @@ h1 {
     "@types/react-dom": "^17.0.0",
     typescript: "^4.0.0",
   },
-  entry: "/index.tsx",
-  main: "/App.tsx",
+  entry: "/src/index.tsx",
+  main: "/src/App.tsx",
   environment: "create-react-app",
 };

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -97,7 +97,7 @@ export type SandboxEnvironment = ITemplate;
 export type SandpackPredefinedTemplate =
   | "angular"
   | "react"
-  | "react-typescript"
+  | "react-ts"
   | "vanilla"
   | "vue"
   | "vue3";

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -70,6 +70,7 @@ export type EditorState = "pristine" | "dirty";
 export interface SandboxTemplate {
   files: SandpackBundlerFiles;
   dependencies: Record<string, string>;
+  devDependencies?: Record<string, string>;
   entry: string;
   main: string;
   environment: SandboxEnvironment;
@@ -96,6 +97,7 @@ export type SandboxEnvironment = ITemplate;
 export type SandpackPredefinedTemplate =
   | "angular"
   | "react"
+  | "react-typescript"
   | "vanilla"
   | "vue"
   | "vue3";

--- a/sandpack-react/src/utils/sandpackUtils.ts
+++ b/sandpack-react/src/utils/sandpackUtils.ts
@@ -78,7 +78,9 @@ export const getSandpackStateFromProps = (
   const files = addPackageJSONIfNeeded(
     projectSetup.files,
     projectSetup.dependencies || {},
-    projectSetup.entry
+    projectSetup.entry,
+    // @ts-ignore FIXME: remove this as soon as the sandpack-client typings are up-to-date
+    projectSetup.devDependencies
   );
 
   const environment = projectSetup.environment;
@@ -129,6 +131,10 @@ export const getSetup = (
     dependencies: {
       ...baseTemplate.dependencies,
       ...setup.dependencies,
+    },
+    devDependencies: {
+      ...baseTemplate.devDependencies,
+      ...setup.devDependencies,
     },
     entry: setup.entry || baseTemplate.entry,
     main: setup.main || baseTemplate.main,

--- a/sandpack-react/src/utils/sandpackUtils.ts
+++ b/sandpack-react/src/utils/sandpackUtils.ts
@@ -78,9 +78,9 @@ export const getSandpackStateFromProps = (
   const files = addPackageJSONIfNeeded(
     projectSetup.files,
     projectSetup.dependencies || {},
-    projectSetup.entry,
+    projectSetup.devDependencies || {},
     // @ts-ignore FIXME: remove this as soon as the sandpack-client typings are up-to-date
-    projectSetup.devDependencies
+    projectSetup.entry
   );
 
   const environment = projectSetup.environment;

--- a/sandpack-react/src/utils/sandpackUtils.ts
+++ b/sandpack-react/src/utils/sandpackUtils.ts
@@ -79,7 +79,6 @@ export const getSandpackStateFromProps = (
     projectSetup.files,
     projectSetup.dependencies || {},
     projectSetup.devDependencies || {},
-    // @ts-ignore FIXME: remove this as soon as the sandpack-client typings are up-to-date
     projectSetup.entry
   );
 


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Resolves #108 

## What is the new behavior?

Provide a predefined template for react with out-of-the-box support for typescript

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

Extended Storybook

## Checklist

- [x] Documentation "N/A"
- [x] Ready to be merged

The public API of 'sandpack-client' has changed (added new param for 'devDependencies'). Not sure how the release process works but the `ts-ignore` from `sandpackUtils.ts` has to go.
Also prettier added some formatting but I can only assume the previous code was incorrectly formatted.
