### PR TITLE
fix(react): make instructions elements ids unique

### DIFF
--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -24,7 +24,7 @@ import * as React from "react";
 import { useSandpack } from "../../hooks/useSandpack";
 import { useSandpackTheme } from "../../hooks/useSandpackTheme";
 import type { EditorState as SandpackEditorState } from "../../types";
-import { getFileName } from "../../utils/stringUtils";
+import { getFileName, generateRandomId } from "../../utils/stringUtils";
 
 import { highlightDecorators } from "./highlightDecorators";
 import { highlightInlineError } from "./highlightInlineError";
@@ -88,6 +88,7 @@ export const CodeMirror = React.forwardRef<HTMLElement, CodeMirrorProps>(
     const [internalCode, setInternalCode] = React.useState<string>(code);
     const c = useClasser("sp");
     const { listen } = useSandpack();
+    const ariaId = React.useRef<string>(generateRandomId());
 
     React.useEffect(() => {
       if (!wrapper.current) {
@@ -195,7 +196,10 @@ export const CodeMirror = React.forwardRef<HTMLElement, CodeMirrorProps>(
 
       if (!readOnly) {
         view.contentDOM.setAttribute("tabIndex", "-1");
-        view.contentDOM.setAttribute("aria-describedby", "exit-instructions");
+        view.contentDOM.setAttribute(
+          "aria-describedby",
+          `exit-instructions-${ariaId.current}`
+        );
       }
 
       cmView.current = view;
@@ -299,7 +303,7 @@ export const CodeMirror = React.forwardRef<HTMLElement, CodeMirrorProps>(
       /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
       <div
         ref={combinedRef}
-        aria-describedby="enter-instructions"
+        aria-describedby={`enter-instructions-${ariaId.current}`}
         aria-label={
           filePath ? `Code Editor for ${getFileName(filePath)}` : `Code Editor`
         }
@@ -319,11 +323,17 @@ export const CodeMirror = React.forwardRef<HTMLElement, CodeMirrorProps>(
         </pre>
 
         <>
-          <p id="enter-instructions" style={{ display: "none" }}>
+          <p
+            id={`enter-instructions-${ariaId.current}`}
+            style={{ display: "none" }}
+          >
             To enter the code editing mode, press Enter. To exit the edit mode,
             press Escape
           </p>
-          <p id="exit-instructions" style={{ display: "none" }}>
+          <p
+            id={`exit-instructions-${ariaId.current}`}
+            style={{ display: "none" }}
+          >
             You are editing the code. To exit the edit mode, press Escape
           </p>
         </>


### PR DESCRIPTION
## What kind of change does this pull request introduce?

The instructions elements ids in each code block must be unique, otherwise you will get the following HTML errors if you use more than one code block on web page: 

> Duplicate ID “enter-instructions”.
> The id attribute is used to identify a single element within a document, and is required to be unique. Check the document for repeated IDs.

## What is the current behavior?

When I try to check the site with the W3C Validator, I get the "Duplicate ID" errors (see https://validator.w3.org/nu/?doc=https%3A%2F%2Fbeta.reactjs.org%2Flearn for example).

## What is the new behavior?

No any "Duplicate ID" errors when validator checks web page that contains multiple code blocks.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Include two code blocks on same web page
2. Try to validate final HTML markup on https://validator.w3.org/
3. Make sure that no "Duplicate ID" errors such have been detected 

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
