### PR TITLE
feat(client): expose of the externalResources

### DIFF
--- a/sandpack-client/src/client.ts
+++ b/sandpack-client/src/client.ts
@@ -22,6 +22,10 @@ import {
 
 export interface ClientOptions {
   /**
+   * Paths to external resources
+   */
+  externalResources?: string[];
+  /**
    * Location of the bundler.
    */
   bundlerURL?: string;
@@ -265,7 +269,7 @@ export class SandpackClient {
       version: 3,
       isInitializationCompile,
       modules,
-      externalResources: [],
+      externalResources: this.options.externalResources || [],
       hasFileResolver: Boolean(this.options.fileResolver),
       disableDependencyPreprocessing:
         this.sandboxInfo.disableDependencyPreprocessing,

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -47,6 +47,7 @@ export interface SandpackProviderProps {
   // editor state (override values)
   activePath?: string;
   openPaths?: string[];
+  externalResources?: string[];
 
   // execution and recompile
   recompileMode?: "immediate" | "delayed";
@@ -293,6 +294,7 @@ class SandpackProvider extends React.PureComponent<
         template: this.state.environment,
       },
       {
+        externalResources: this.props.externalResources,
         bundlerURL: this.props.bundlerURL,
         startRoute: this.props.startRoute,
         fileResolver: this.props.fileResolver,

--- a/website/docs/docs/advanced-usage/client.md
+++ b/website/docs/docs/advanced-usage/client.md
@@ -138,6 +138,10 @@ to render inside the iframe:
 ```ts
 {
   /**
+   * Paths to external resources
+   */
+  externalResources?: string[];
+  /**
    * Location of the bundler. Defaults to `${version}-sandpack.codesandbox.io`
    */
   bundlerURL?: string;

--- a/website/docs/docs/getting-started/custom-content.md
+++ b/website/docs/docs/getting-started/custom-content.md
@@ -130,6 +130,32 @@ default:
 The `active` flag has precendence over the `hidden` flag. So a file with both of these set as `true` will be visible.
 :::
 
+### Links on external resources
+
+You can also use `externalResources` property to specify the static links on external resources such as CSS files or images presence somewhere in the web:
+
+```jsx
+<Sandpack
+  files={{
+    '/App.js': reactCode,
+    '/button.js': {
+      code: buttonCode,
+      active: true,
+    }
+    '/link.js': {
+      code: linkCode,
+      hidden: true,
+    },
+  }}
+  options={{
+    'externalResources': [
+      "https://unpkg.com/@tailwindcss/ui/dist/tailwind-ui.min.css"
+    ]
+  }}
+  template="react"
+/>
+```
+
 ### openPaths and activePath
 
 You can override the entire hidden/active system with two settings (`openPaths` and `activePath`) inside the


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Here is the implementation of the feature request [119](https://github.com/codesandbox/sandpack/issues/119): 

> Expose the externalResources in sandpack-client and sandpack-react.

## What is the current behavior?

There is not possible to specify the external resources such as CSS files or images existing somewhere in the web.

## What is the new behavior?

It would be possible to include the links to external resources via options in sandpack-client or sandpack-react:

```jsx
<Sandpack 
    template="react"
    files={{
      "/App.js": reactButtonCode,
      "/button.js": buttonCode,
    }}
    options={{
      openPaths: ["/App.js", "/button.js", "/index.js"],
      activePath: "/index.js",  
      externalResources: [
        "https://unpkg.com/@tailwindcss/ui/dist/tailwind-ui.min.css"
      ]
    }} />
```

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Create React project
2. Install Sandpack via `yarn add @codesandbox/sandpack-react`
3. Add the following content to the `App.jsx` file:
```
import { Sandpack } from "@codesandbox/sandpack-react";
import "@codesandbox/sandpack-react/dist/index.css";

<Sandpack template="react" options={{externalResources: ["https://unpkg.com/@tailwindcss/ui/dist/tailwind-ui.min.css"]}} />;
```
4. Check that the link on resource exists in iframe:
```html
<link id="external-css" rel="stylesheet" type="text/css" href="https://unpkg.com/@tailwindcss/ui/dist/tailwind-ui.min.css" media="all">
```

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
