### PR TITLE
Vertical component for nested sandpack on the documentation

### DIFF
--- a/website/docs/src/NestedSandpack.tsx
+++ b/website/docs/src/NestedSandpack.tsx
@@ -1,4 +1,4 @@
-import { Sandpack } from "./CustomSandpack";
+import { Sandpack, SandpackLayout } from "./CustomSandpack";
 import React from "react";
 
 const indexCode = `import React, { StrictMode } from "react";
@@ -41,25 +41,24 @@ export default function App() {
 }
 `;
   return (
-    <Sandpack
-      template="react"
-      files={{
-        "/App.js": appCode,
-        "/index.js": {
-          code: indexCode,
-          hidden: true,
-        },
-      }}
-      options={{
-        editorHeight: 500,
-      }}
-      customSetup={{
-        dependencies: {
-          "@codesandbox/sandpack-react": "^0.3.3",
-        },
-      }}
-      {...props}
-    />
+    <div className="nestedSandpack">
+      <Sandpack
+        template="react"
+        files={{
+          "/App.js": appCode,
+          "/index.js": {
+            code: indexCode,
+            hidden: true,
+          },
+        }}
+        customSetup={{
+          dependencies: {
+            "@codesandbox/sandpack-react": "^0.3.3",
+          },
+        }}
+        {...props}
+      />
+    </div>
   );
 };
 

--- a/website/docs/src/scss/_code.scss
+++ b/website/docs/src/scss/_code.scss
@@ -19,3 +19,32 @@ code {
   --sp-colors-fg-active: #f0fdaf;
   display: block;
 }
+
+.nestedSandpack > .sp-wrapper > .sp-layout {
+  display: block;
+}
+
+.nestedSandpack > .sp-wrapper > .sp-layout .sp-stack + .sp-stack {
+  height: 400px;
+}
+
+.sp-wrapper *::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+/* Track */
+.sp-wrapper *::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0);
+}
+
+/* Handle */
+.sp-wrapper *::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 9999px;
+}
+
+/* Handle on hover */
+.sp-wrapper *::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.3);
+}


### PR DESCRIPTION
@sannek here is the vertical component. I would like to customize more the second preview but that will require not used the Sandpack component and loose all the default styles. Maybe in a next iteration?

![image](https://user-images.githubusercontent.com/1891339/143303091-4c6f78b5-26d5-48e0-8e3f-c07425dee157.png)
