### PR TITLE
Update last example

### DIFF
--- a/website/landing/components/Intro/Sections/Layout.tsx
+++ b/website/landing/components/Intro/Sections/Layout.tsx
@@ -83,7 +83,7 @@ export const LayoutExample: React.FC = () => {
             }}
           >
             <SandpackThemeProvider theme="sandpack-dark">
-              <SandpackCodeEditor />
+              <SandpackCodeEditor showTabs={false} />
             </SandpackThemeProvider>
           </CodeWrapper>
         </Content>

--- a/website/landing/components/Intro/Sections/LayoutContext.tsx
+++ b/website/landing/components/Intro/Sections/LayoutContext.tsx
@@ -21,12 +21,26 @@ const LayoutContext = createContext<Context>({
 export const useLayoutExampleContext = (): Context => useContext(LayoutContext);
 
 const ORIGINAL_CODE = {
-  "/App.js": `import {
-  SandpackProvider,
-  SandpackThemeProvider,
-  SandpackCodeEditor,
-  SandpackTranspiledCode,
-} from "@codesandbox/sandpack-react";
+  "/styles.css": `body {
+  font-family: sans-serif;
+  -webkit-font-smoothing: auto;
+  -moz-font-smoothing: auto;
+  -moz-osx-font-smoothing: grayscale;
+  font-smoothing: auto;
+  text-rendering: optimizeLegibility;
+  font-smooth: always;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+}
+
+.sp-transpiled-code .sp-tabs { 
+  display: none;
+}
+
+h1 {
+  font-size: 1.5rem;
+}`,
+  "/App.js": `import { SandpackProvider, SandpackThemeProvider, SandpackCodeEditor, SandpackTranspiledCode } from "@codesandbox/sandpack-react";
 import "@codesandbox/sandpack-react/dist/index.css";
 
 export default () => (


### PR DESCRIPTION
- Remove tabs from transpiler.
- Remove tabs from the codeblock
- Keep long importer in one line to make easy to scan

![image](https://user-images.githubusercontent.com/1891339/143313288-c13c7343-6203-48f6-b61e-fc7bab4d074b.png)
