### PR TITLE
fix(init-mode): render placeholder

### DIFF
--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -208,13 +208,6 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
         });
 
         const parentDiv = wrapper.current;
-        const existingPlaceholder = parentDiv.querySelector(
-          ".sp-pre-placeholder"
-        );
-
-        if (existingPlaceholder) {
-          parentDiv.removeChild(existingPlaceholder);
-        }
 
         const view = new EditorView({
           state: startState,
@@ -334,7 +327,7 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
     if (readOnly) {
       return (
         <pre ref={combinedRef} className={c("cm", editorState)} translate="no">
-          <code className={c("pre-placeholder")}>{code}</code>
+          {!initEditor && <code className={c("pre-placeholder")}>{code}</code>}
         </pre>
       );
     }
@@ -354,14 +347,16 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
         tabIndex={0}
         translate="no"
       >
-        <pre
-          className={c("pre-placeholder")}
-          style={{
-            marginLeft: showLineNumbers ? 28 : 0, // gutter line offset
-          }}
-        >
-          {code}
-        </pre>
+        {!initEditor && (
+          <pre
+            className={c("pre-placeholder")}
+            style={{
+              marginLeft: showLineNumbers ? 28 : 0, // gutter line offset
+            }}
+          >
+            {code}
+          </pre>
+        )}
 
         <>
           <p

--- a/website/landing/package.json
+++ b/website/landing/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@codesandbox/sandpack-react": "^0.7.2",
+    "@codesandbox/sandpack-react": "^0.8.0",
     "@stitches/react": "^1.2.5",
     "framer-motion": "^5.3.2",
     "next": "12.0.2",


### PR DESCRIPTION
When `initMode` is on `user-visible` or `lazy` mode, there is no placeholder rendered in place of the Codemirror editor. So this PR ensures that there is always a kind of component with the `code` being rendered regardless the of the editor status. 