### PR TITLE
docs: add theme builder

### DIFF
--- a/website/docs/docs/getting-started/custom-ui.md
+++ b/website/docs/docs/getting-started/custom-ui.md
@@ -21,13 +21,13 @@ Sandpack comes with some predefined themes:
 To see all the themes at a glance, use [this sandbox](https://codesandbox.io/s/sandpack-theme-yqsmj)
 
 <!-- prettier-ignore -->
-<NestedSandpack nestedProps={`  // Try out the included themes below!
-    theme="codesandbox-dark"
-    // theme="codesandbox-light"
-    // theme="github-light"
-    // theme="night-owl"
-    // theme="aqua-blue"
-    // theme="monokai-pro"`}
+<NestedSandpack nestedProps={`    // Try out the included themes below!
+      theme="dark"
+      // theme="light"
+      // theme="github-light"
+      // theme="night-owl"
+      // theme="aqua-blue"
+      // theme="monokai-pro"`}
 />
 
 ### Custom Theme
@@ -37,29 +37,34 @@ You can also pass a **partial** theme object that overrides properties in the
 
 <!-- prettier-ignore -->
 <NestedSandpack nestedProps={`    theme={{
-      palette: {
-        accent: "rebeccapurple",
-      },
-      syntax: {
-        tag: "#006400",
-        string: "rgb(255, 165, 0)",
-        plain: "tomato",
-      },
-    }}`}
+        palette: {
+          accent: "rebeccapurple",
+        },
+        syntax: {
+          tag: "#006400",
+          string: "rgb(255, 165, 0)",
+          plain: "tomato",
+        },
+      }}`}
   />
+
+:::success Sandpack Theme Builder
+Use can design and customize your own theme, among other Sandpack presets. [Try it now! ↗](https://sandpack.codesandbox.io/theme)
+:::
 
 Furthermore you can import an existing theme object and use object composition to override specific fields.
 
 <!-- prettier-ignore -->
 <NestedSandpack 
-  setupCode={`import { Sandpack, codesandboxDarkTheme } from "@codesandbox/sandpack-react";`} 
+  setupCode={`import { Sandpack, codesandboxDarkTheme } from "@codesandbox/sandpack-react";
+import "@codesandbox/sandpack-react/dist/index.css";`} 
   nestedProps={`    theme={{
-      ...codesandboxDarkTheme,
-      typography: {
-        fontSize: "16px",
-        bodyFont: "Arial",
-      },
-    }}`}
+        ...codesandboxDarkTheme,
+        typography: {
+          fontSize: "16px",
+          bodyFont: "Arial",
+        },
+      }}`}
   />
 
 ## Custom Styling

--- a/website/docs/docs/getting-started/custom-ui.md
+++ b/website/docs/docs/getting-started/custom-ui.md
@@ -49,7 +49,7 @@ You can also pass a **partial** theme object that overrides properties in the
   />
 
 :::success Sandpack Theme Builder
-Use can design and customize your own theme, among other Sandpack presets. [Try it now! ↗](https://sandpack.codesandbox.io/theme)
+You can design your own theme or customize any existing Sandpack theme presets. [Try it now! ↗](https://sandpack.codesandbox.io/theme)
 :::
 
 Furthermore you can import an existing theme object and use object composition to override specific fields.

--- a/website/docs/src/NestedSandpack.tsx
+++ b/website/docs/src/NestedSandpack.tsx
@@ -34,7 +34,7 @@ export default function App() {
       ? nestedProps
       : `    // You can change these examples!
       // Try uncommenting any of these lines
-      // theme="codesandbox-dark"
+      // theme="dark"
       // template="react"`
   }
     />


### PR DESCRIPTION
The banner to the Sandpack Theme Builder is the only major change in this PR:
![Screenshot 2021-11-30 at 19 12 57](https://user-images.githubusercontent.com/4838076/144112674-a30911e9-012c-4c0e-8b8f-77368dcd9b00.png)
