### PR TITLE
fix: landing - cropped editor tabs on hero editor

### DIFF
--- a/website/landing/components/Hero/HeroDesktop/HeroDesktop.tsx
+++ b/website/landing/components/Hero/HeroDesktop/HeroDesktop.tsx
@@ -220,6 +220,7 @@ export const HeroDesktop: React.FC = () => {
 
             ".sp-tabs-scrollable-container": {
               alignItems: "center",
+              height: "auto",
               paddingTop: "16px",
               paddingBottom: "2px",
             },


### PR DESCRIPTION
## What kind of change does this pull request introduce?
<!-- Is it a Bug fix, feature, documentation update... -->

Fixes cropped tab on the hero's editor.

## What is the current behavior?
<!-- if this is a feature change -->

![localhost_3001_ (1)](https://user-images.githubusercontent.com/24959348/144317552-e00cb9d6-e059-4005-b9d1-d37de4b1f130.png)

## What is the new behavior?
<!-- You can also link to an open issue here -->

![localhost_3001_](https://user-images.githubusercontent.com/24959348/144317463-34e76bff-49d9-441a-9f4e-9f07d78f6c54.png)

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

[x] Chrome
[x] Safari
[x] FF

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
