### PR TITLE
docs: changed the arrows

### DIFF
--- a/website/docs/docs/intro.md
+++ b/website/docs/docs/intro.md
@@ -22,11 +22,11 @@ deeper into our ecosystem.
 ### Getting Started
 
 <div class="intro-section">
-  <IntroCard title="Install" description="Learn how to add Sandpack to your projects and start coding in minutes." href="/docs/getting-started/install" actionText="Access ->" />
+  <IntroCard title="Install" description="Learn how to add Sandpack to your projects and start coding in minutes." href="/docs/getting-started/install" actionText="Access &#8594;" />
 
-  <IntroCard title="Advanced Usage" description="An overview of some Sandpack capabilities and how to extend its API." href="/docs/advanced-usage/provider" actionText="Access ->" />
+  <IntroCard title="Advanced Usage" description="An overview of some Sandpack capabilities and how to extend its API." href="/docs/advanced-usage/provider" actionText="Access &#8594;" />
 
-  <IntroCard title="API reference" description="A full listing and description of the public API exported by the libraries." href="/docs/api/react/components/" actionText="Access ->" />
+  <IntroCard title="API reference" description="A full listing and description of the public API exported by the libraries." href="/docs/api/react/components/" actionText="Access &#8594;" />
 
   <IntroCard title="Sandpack Theme Builder" description="Design and customize your own theme, among other Sandpack presets." href="https://sandpack.codesandbox.io/theme" actionText="Try it now" external />
 </div>


### PR DESCRIPTION
### What kind of change does this pull request introduce?
Small content fix  Updated the Arrows on the documentation Page

### What is the current behavior?
**Old Arrows**
<img width="201" alt="Screenshot 2021-12-03 at 10 02 11" src="https://user-images.githubusercontent.com/46239581/144575740-40f40257-b775-4a0f-925f-e7c3dc87180a.png">
FileExplorer is not usable, unlike, for example FileTabs.

### What is the new behavior?
**New Arrows**
<img width="246" alt="Screenshot 2021-12-03 at 10 01 51" src="https://user-images.githubusercontent.com/46239581/144575734-e53e1436-42ce-4ad0-8d67-cb6cc7b9d19e.png">

### What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.
Checked diffrent browsers 

###Documentation N/A
  
  Ready to be merged
