### PR TITLE
fix(types): react components not actually accepting children

### DIFF
--- a/sandpack-react/src/components/CodeEditor/CodeEditor.stories.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeEditor.stories.tsx
@@ -1,5 +1,5 @@
 import type { Story } from "@storybook/react";
-import React from "react";
+import * as React from "react";
 
 import { SandpackProvider } from "../../contexts/sandpackContext";
 import { SandpackThemeProvider } from "../../contexts/themeContext";

--- a/sandpack-react/src/components/CodeEditor/CodeMirror.stories.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 import { SandpackProvider } from "../../contexts/sandpackContext";
 import { SandpackThemeProvider } from "../../contexts/themeContext";

--- a/sandpack-react/src/components/CodeEditor/utils.ts
+++ b/sandpack-react/src/components/CodeEditor/utils.ts
@@ -6,8 +6,7 @@ import type { LanguageSupport } from "@codemirror/language";
 import type { Extension } from "@codemirror/state";
 import type { Text } from "@codemirror/text";
 import { EditorView } from "@codemirror/view";
-import type { Ref } from "react";
-import { useCallback } from "react";
+import * as React from "react";
 
 import { getSyntaxStyle } from "../../themes";
 import type { SandpackTheme } from "../../types";
@@ -153,9 +152,9 @@ export const getCodeMirrorLanguage = (
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const useCombinedRefs = <T extends any>(
-  ...refs: Array<Ref<T>>
-): Ref<T> =>
-  useCallback(
+  ...refs: Array<React.Ref<T>>
+): React.Ref<T> =>
+  React.useCallback(
     (element: T) =>
       refs.forEach((ref) => {
         if (!ref) {

--- a/sandpack-react/src/components/CodeViewer/CodeViewer.stories.tsx
+++ b/sandpack-react/src/components/CodeViewer/CodeViewer.stories.tsx
@@ -1,5 +1,5 @@
 import type { Story } from "@storybook/react";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import * as React from "react";
 
 import { SandpackProvider } from "../../contexts/sandpackContext";
 import { SandpackThemeProvider } from "../../contexts/themeContext";
@@ -61,10 +61,10 @@ export const VueCode: React.FC = () => (
 );
 
 export const Decorators: React.FC = () => {
-  const [itemClick, setItemClicked] = useState();
-  const ref = useRef<HTMLDivElement>();
+  const [itemClick, setItemClicked] = React.useState();
+  const ref = React.useRef<HTMLDivElement>();
 
-  useEffect(() => {
+  React.useEffect(() => {
     const handle = (event) => {
       let id = event.target.dataset.id;
 

--- a/sandpack-react/src/components/CodeViewer/index.tsx
+++ b/sandpack-react/src/components/CodeViewer/index.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { forwardRef } from "react";
 
 import type { SandpackInitMode } from "../..";
 import { RunButton } from "../../common/RunButton";
@@ -29,7 +28,10 @@ export interface CodeViewerProps {
 /**
  * @category Components
  */
-export const SandpackCodeViewer = forwardRef<CodeEditorRef, CodeViewerProps>(
+export const SandpackCodeViewer = React.forwardRef<
+  CodeEditorRef,
+  CodeViewerProps
+>(
   (
     {
       showTabs,

--- a/sandpack-react/src/components/FileExplorer/FileExplorer.stories.tsx
+++ b/sandpack-react/src/components/FileExplorer/FileExplorer.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 import { SandpackLayout } from "../../common/Layout";
 import { SandpackCodeEditor } from "../../components/CodeEditor";

--- a/sandpack-react/src/components/FileExplorer/index.tsx
+++ b/sandpack-react/src/components/FileExplorer/index.tsx
@@ -8,7 +8,7 @@ import { ModuleList } from "./ModuleList";
 /**
  * @category Components
  */
-export const FileExplorer: React.FC = () => {
+export const FileExplorer = (): JSX.Element => {
   const { sandpack } = useSandpack();
 
   return (

--- a/sandpack-react/src/components/FileTabs/FileTabs.stories.tsx
+++ b/sandpack-react/src/components/FileTabs/FileTabs.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 import { SandpackLayout } from "../../common/Layout";
 import { SandpackProvider } from "../../contexts/sandpackContext";

--- a/sandpack-react/src/components/FileTabs/index.tsx
+++ b/sandpack-react/src/components/FileTabs/index.tsx
@@ -5,12 +5,14 @@ import { useSandpack } from "../../hooks/useSandpack";
 import { CloseIcon } from "../../icons";
 import { getFileName } from "../../utils/stringUtils";
 
+export interface FileTabsProps {
+  closableTabs?: boolean;
+}
+
 /**
  * @category Components
  */
-export const FileTabs: React.FC<{ closableTabs?: boolean }> = ({
-  closableTabs,
-}) => {
+export const FileTabs = ({ closableTabs }: FileTabsProps): JSX.Element => {
   const { sandpack } = useSandpack();
   const c = useClasser("sp");
 

--- a/sandpack-react/src/components/Navigator/Navigator.stories.tsx
+++ b/sandpack-react/src/components/Navigator/Navigator.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 import { SandpackLayout } from "../../common/Layout";
 import { SandpackProvider } from "../../contexts/sandpackContext";

--- a/sandpack-react/src/components/Navigator/index.tsx
+++ b/sandpack-react/src/components/Navigator/index.tsx
@@ -14,10 +14,10 @@ export interface NavigatorProps {
 /**
  * @category Components
  */
-export const Navigator: React.FC<NavigatorProps> = ({
+export const Navigator = ({
   clientId,
   onURLChange,
-}) => {
+}: NavigatorProps): JSX.Element => {
   const [baseUrl, setBaseUrl] = React.useState<string>("");
   const { sandpack, dispatch, listen } = useSandpack();
 

--- a/sandpack-react/src/components/Preview/Preview.stories.tsx
+++ b/sandpack-react/src/components/Preview/Preview.stories.tsx
@@ -1,5 +1,5 @@
 import type { Story } from "@storybook/react";
-import React from "react";
+import * as React from "react";
 
 import { SandpackLayout } from "../../common/Layout";
 import { SandpackProvider } from "../../contexts/sandpackContext";

--- a/sandpack-react/src/components/Preview/RefreshButton.tsx
+++ b/sandpack-react/src/components/Preview/RefreshButton.tsx
@@ -4,12 +4,16 @@ import * as React from "react";
 import { useSandpackNavigation } from "../../hooks/useSandpackNavigation";
 import { RefreshIcon } from "../../icons";
 
+interface RefreshButtonProps {
+  clientId?: string;
+}
+
 /**
  * @category Components
  */
-export const RefreshButton: React.FC<{
-  clientId?: string;
-}> = ({ clientId }) => {
+export const RefreshButton = ({
+  clientId,
+}: RefreshButtonProps): JSX.Element => {
   const { refresh } = useSandpackNavigation(clientId);
   const c = useClasser("sp");
 

--- a/sandpack-react/src/components/Preview/index.tsx
+++ b/sandpack-react/src/components/Preview/index.tsx
@@ -39,7 +39,7 @@ export { RefreshButton };
 /**
  * @category Components
  */
-export const SandpackPreview: React.FC<PreviewProps> = ({
+export const SandpackPreview = ({
   customStyle,
   showNavigator = false,
   showRefreshButton = true,
@@ -47,7 +47,7 @@ export const SandpackPreview: React.FC<PreviewProps> = ({
   showSandpackErrorOverlay = true,
   viewportSize = "auto",
   viewportOrientation = "portrait",
-}) => {
+}: PreviewProps): JSX.Element => {
   const { sandpack, listen } = useSandpack();
   const [iframeComputedHeight, setComputedAutoHeight] = React.useState<
     number | null

--- a/sandpack-react/src/components/TranspiledCode/TranspiledCodeView.stories.tsx
+++ b/sandpack-react/src/components/TranspiledCode/TranspiledCodeView.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 import { SandpackLayout } from "../../common/Layout";
 import { SandpackStack } from "../../common/Stack";

--- a/sandpack-react/src/components/TranspiledCode/index.tsx
+++ b/sandpack-react/src/components/TranspiledCode/index.tsx
@@ -11,7 +11,7 @@ import { SandpackCodeViewer } from "../CodeViewer";
 /**
  * @category Components
  */
-export const SandpackTranspiledCode: React.FC<CodeViewerProps> = (props) => {
+export const SandpackTranspiledCode = (props: CodeViewerProps): JSX.Element => {
   const { sandpack } = useSandpack();
   const transpiledCode = useTranspiledCode();
   const c = useClasser("sp");


### PR DESCRIPTION
## What kind of change does this pull request introduce?

TS types fix

## What is the current behavior?

Most of the react components implemented the React.FC type, implying they accept `children` while they actually don't.

React.FC in still supported by react for backwards compatibility, but has been recognised officially as an anti-pattern for a while.

Here are some readings about this:
- https://github.com/typescript-cheatsheets/react#function-components (section "Why is `React.FC` discouraged?")
- https://kentcdodds.com/blog/how-to-write-a-react-component-in-typescript
- https://dev.to/wojciechmatuszewski/top-three-react-typescript-pitfalls-50l8
- https://fettblog.eu/typescript-react-why-i-dont-use-react-fc/

## What is the new behavior?

Components are not falsely types as supporting children.

Additionally, react imports have been unified to the `import * from React` pattern that seem to be used in the majority of the other files.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Checked in the code that the affected components are not rendering props.children

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
