### PR TITLE
fix(landing): set pointerEvents to avoid reset button overlap

### DIFF
--- a/website/landing/components/Intro/Sections/Custom.tsx
+++ b/website/landing/components/Intro/Sections/Custom.tsx
@@ -130,6 +130,7 @@ export const CustomExample: React.FC = () => {
                 onClick={() => {
                   sandpack.updateCurrentFile(ORIGINAL_CODE);
                 }}
+                style={{ opacity: code === ORIGINAL_CODE ? 0.3 : 1 }}
               >
                 <svg
                   fill="currentColor"

--- a/website/landing/components/Intro/Sections/Editor.tsx
+++ b/website/landing/components/Intro/Sections/Editor.tsx
@@ -132,6 +132,7 @@ export const EditorExample: React.FC = () => {
                   sandpack.updateCurrentFile(ORIGINAL_CODE);
                   setOptions(ORIGINAL_CUSTOM);
                 }}
+                style={{ opacity: code === ORIGINAL_CODE ? 0.3 : 1 }}
               >
                 <svg
                   fill="currentColor"

--- a/website/landing/components/Intro/Sections/common.tsx
+++ b/website/landing/components/Intro/Sections/common.tsx
@@ -201,12 +201,13 @@ export const FadeAnimation: React.FC = ({ children }) => {
     ],
     [shouldAnimate ? 0 : 1, 1, 1, 1, 1, shouldAnimate ? 0 : 1]
   );
+  const pointerEvents = opacity.get() ? "auto" : "none";
 
   return (
     <motion.li
       ref={sectionRef}
       className="fade-animation"
-      style={{ opacity, width: "100%" }}
+      style={{ opacity, pointerEvents, width: "100%" }}
     >
       {children}
     </motion.li>


### PR DESCRIPTION
## What kind of change does this pull request introduce?

<!-- Is it a Bug fix, feature, documentation update... -->
1. Fix a bug blocking interaction with editors due to invisible elements overlapping
2. Dim reset button when the editor contents are unchanged

## What is the current behavior?

1. 

https://user-images.githubusercontent.com/4658208/145232138-43761d11-8c49-4088-9f7b-6d36dd582a5e.mp4

2. Reset button gives the impression that the reset button will do _something_ while it's visible.

<!-- You can also link to an open issue here -->

## What is the new behavior?

1. Invisible elements are given `pointerEvents: "none"`.
2. Reset button is dimmed if editor contents are unchanged.

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

Locally tested both interactions:
1. Reset button now works consistently.
2. Reset button is dimmed until changes are made in the editor.

https://user-images.githubusercontent.com/4658208/145233783-d87b7943-ff6f-452a-9906-43738de195fa.mp4


## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
