### PR TITLE
docs(codeblock): add copy button

### DIFF
--- a/plugins/docusaurus/src/theme/CodeBlock/index.jsx
+++ b/plugins/docusaurus/src/theme/CodeBlock/index.jsx
@@ -60,6 +60,30 @@ const RenderSandpack = (props) => {
       }}
     >
       <SandpackThemeProvider theme={theme}>
+        <button
+          className="sandpack__copy-button"
+          onClick={() => {
+            navigator.clipboard.writeText(children.trim());
+          }}
+        >
+          <svg fill="none" height="100%" viewBox="0 0 12 13" width="100%">
+            <g clipPath="url(#a)">
+              <path
+                d="M8.21 1.344H2.317c-.54 0-.983.463-.983 1.03v7.212h.983V2.374H8.21v-1.03Zm1.474 2.06H4.281c-.54 0-.983.464-.983 1.03v7.213c0 .566.442 1.03.983 1.03h5.403c.54 0 .983-.464.983-1.03V4.435c0-.567-.442-1.03-.983-1.03Zm0 8.243H4.281V4.435h5.403v7.212Z"
+                fill="currentColor"
+              />
+            </g>
+            <defs>
+              <clipPath id="a">
+                <path
+                  d="M0 0h12v12H0z"
+                  fill="currentColor"
+                  transform="translate(0 .676)"
+                />
+              </clipPath>
+            </defs>
+          </svg>
+        </button>
         <SandpackCodeViewer />
       </SandpackThemeProvider>
     </SandpackProvider>

--- a/plugins/docusaurus/src/theme/CodeBlock/style.css
+++ b/plugins/docusaurus/src/theme/CodeBlock/style.css
@@ -1,5 +1,28 @@
 @import "@codesandbox/sandpack-react/dist/index.css";
 
 .sp-wrapper {
-    margin-bottom: 2em;
+  margin-bottom: 2em;
+  position: relative;
+}
+
+.sp-wrapper:hover .sandpack__copy-button {
+  opacity: 1;
+}
+
+.sandpack__copy-button {
+  background: none;
+  border: 0;
+  width: 24px;
+
+  position: absolute;
+  right: 1em;
+  top: 1.5em;
+
+  z-index: 99;
+  color: #fff;
+
+  opacity: 0;
+
+  transition: 0.2s ease;
+  cursor: pointer;
 }

--- a/website/landing/components/common/Clipboard.tsx
+++ b/website/landing/components/common/Clipboard.tsx
@@ -1,7 +1,8 @@
 import content from "../../website.config.json";
 
-import { Box, Button, Text } from ".";
 import { useClipboard } from "./ClipboardProvider";
+
+import { Box, Button, Text } from ".";
 
 export const Clipboard: React.FC = () => {
   const { copyToClipboard } = useClipboard();


### PR DESCRIPTION
Adds a copy button on CodeBlock: 
<img width="921" alt="Screenshot 2021-12-09 at 15 32 20" src="https://user-images.githubusercontent.com/4838076/145426389-afc88f51-c10d-4f6c-910f-ea89869023ba.png">
