### PR TITLE
fix(react-devtools): legacy mode

### DIFF
--- a/sandpack-client/src/client.ts
+++ b/sandpack-client/src/client.ts
@@ -13,6 +13,7 @@ import type {
   SandpackMessage,
   ListenerFunction,
   SandpackError,
+  ReactDevToolsMode,
 } from "./types";
 import {
   createPackageJSON,
@@ -67,7 +68,7 @@ export interface ClientOptions {
     readFile: (path: string) => Promise<string>;
   };
 
-  reactDevTools?: boolean;
+  reactDevTools?: ReactDevToolsMode;
 }
 
 export interface SandboxInfo {

--- a/sandpack-client/src/types.ts
+++ b/sandpack-client/src/types.ts
@@ -21,6 +21,8 @@ export type Modules = Record<
 
 export type Dependencies = Record<string, string>;
 
+export type ReactDevToolsMode = "latest" | "legacy" | undefined;
+
 export interface ModuleSource {
   fileName: string;
   compiledCode: string;
@@ -171,7 +173,7 @@ export type SandpackMessage = BaseSandpackMessage &
         showLoadingScreen: boolean;
         skipEval: boolean;
         clearConsoleDisabled?: boolean;
-        reactDevTools?: boolean;
+        reactDevTools?: ReactDevToolsMode;
       }
     | {
         type: "refresh";

--- a/sandpack-client/src/types.ts
+++ b/sandpack-client/src/types.ts
@@ -21,7 +21,7 @@ export type Modules = Record<
 
 export type Dependencies = Record<string, string>;
 
-export type ReactDevToolsMode = "latest" | "legacy" | undefined;
+export type ReactDevToolsMode = "latest" | "legacy";
 
 export interface ModuleSource {
   fileName: string;

--- a/sandpack-react/src/components/ReactDevTools/index.tsx
+++ b/sandpack-react/src/components/ReactDevTools/index.tsx
@@ -45,7 +45,7 @@ export const SandpackReactDevTools = ({
   }, [reactDevtools, clientId, listen, sandpack.clients]);
 
   React.useEffect(() => {
-    sandpack.registerReactDevTools();
+    sandpack.registerReactDevTools("legacy");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/sandpack-react/src/components/ReactDevTools/index.tsx
+++ b/sandpack-react/src/components/ReactDevTools/index.tsx
@@ -5,20 +5,24 @@ import { useSandpackTheme } from "../..";
 import { useSandpack } from "../../hooks/useSandpack";
 import { isDarkColor } from "../../utils/stringUtils";
 
+type DevToolsTheme = "dark" | "light";
+
 export const SandpackReactDevTools = ({
   clientId,
+  theme,
   ...props
 }: {
   clientId?: string;
+  theme?: DevToolsTheme;
 } & React.HtmlHTMLAttributes<unknown>): JSX.Element | null => {
   const { listen, sandpack } = useSandpack();
-  const { theme } = useSandpackTheme();
+  const { theme: sandpackTheme } = useSandpackTheme();
   const c = useClasser("sp");
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const reactDevtools = React.useRef<any>();
 
   const [ReactDevTools, setDevTools] = React.useState<React.FunctionComponent<{
-    browserTheme: "dark" | "light";
+    browserTheme: DevToolsTheme;
   }> | null>(null);
 
   React.useEffect(() => {
@@ -51,11 +55,17 @@ export const SandpackReactDevTools = ({
 
   if (!ReactDevTools) return null;
 
-  const isDarkTheme = isDarkColor(theme.palette.defaultBackground);
+  const getBrowserTheme = (): DevToolsTheme => {
+    if (theme) return theme;
+
+    const isDarkTheme = isDarkColor(sandpackTheme.palette.defaultBackground);
+
+    return isDarkTheme ? "dark" : "light";
+  };
 
   return (
     <div className={c("devtools")} {...props}>
-      <ReactDevTools browserTheme={isDarkTheme ? "dark" : "light"} />
+      <ReactDevTools browserTheme={getBrowserTheme()} />
     </div>
   );
 };

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -5,6 +5,7 @@ import type {
   SandpackError,
   SandpackMessage,
   UnsubscribeFunction,
+  ReactDevToolsMode,
 } from "@codesandbox/sandpack-client";
 import {
   SandpackClient,
@@ -43,7 +44,7 @@ export interface SandpackProviderState {
   editorState: EditorState;
   renderHiddenIframe: boolean;
   initMode: SandpackInitMode;
-  reactDevTools: boolean;
+  reactDevTools: ReactDevToolsMode;
 }
 
 export interface SandpackProviderProps {
@@ -130,7 +131,7 @@ class SandpackProvider extends React.PureComponent<
       editorState: "pristine",
       renderHiddenIframe: false,
       initMode: this.props.initMode || "lazy",
-      reactDevTools: false,
+      reactDevTools: undefined,
     };
 
     /**
@@ -186,8 +187,8 @@ class SandpackProvider extends React.PureComponent<
   /**
    * @hidden
    */
-  registerReactDevTools = (): void => {
-    this.setState({ reactDevTools: true });
+  registerReactDevTools = (value: Required<ReactDevToolsMode>): void => {
+    this.setState({ reactDevTools: value });
   };
 
   /**

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -44,7 +44,7 @@ export interface SandpackProviderState {
   editorState: EditorState;
   renderHiddenIframe: boolean;
   initMode: SandpackInitMode;
-  reactDevTools: ReactDevToolsMode;
+  reactDevTools?: ReactDevToolsMode;
 }
 
 export interface SandpackProviderProps {
@@ -187,7 +187,7 @@ class SandpackProvider extends React.PureComponent<
   /**
    * @hidden
    */
-  registerReactDevTools = (value: Required<ReactDevToolsMode>): void => {
+  registerReactDevTools = (value: ReactDevToolsMode): void => {
     this.setState({ reactDevTools: value });
   };
 

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -48,7 +48,7 @@ export interface SandpackState {
   setActiveFile: (path: string) => void;
   resetFile: (path: string) => void;
   resetAllFiles: () => void;
-  registerReactDevTools: (value: Required<ReactDevToolsMode>) => void;
+  registerReactDevTools: (value: ReactDevToolsMode) => void;
 
   // Element refs
   // Different components inside the SandpackProvider might register certain elements of interest for sandpack

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -1,6 +1,7 @@
 import type {
   BundlerState,
   ListenerFunction,
+  ReactDevToolsMode,
   SandpackBundlerFiles,
   SandpackClient,
   SandpackError,
@@ -47,7 +48,7 @@ export interface SandpackState {
   setActiveFile: (path: string) => void;
   resetFile: (path: string) => void;
   resetAllFiles: () => void;
-  registerReactDevTools: () => void;
+  registerReactDevTools: (value: Required<ReactDevToolsMode>) => void;
 
   // Element refs
   // Different components inside the SandpackProvider might register certain elements of interest for sandpack


### PR DESCRIPTION
This explicitly consumes the legacy version of `react-devtools-inline@4.40` implemented in the CodeSandbox bundler. We have been implementing the ability to consume versions of the React DevTools differently in order to have backward compatibility in the codesandbox.io and support the latest releases of React. 