### PR TITLE
docs(guides): add page

### DIFF
--- a/website/docs/docs/guides.md
+++ b/website/docs/docs/guides.md
@@ -5,4 +5,4 @@ title: Guides
 
 Here you can find some guides or recipes on using the Sandpack in different situations. These examples are basic implementations, and you need to consider improving for production, but you can find more detailed guides in the [advanced usage](/advanced-usage/provider) section.
 
-- Prettier: https://codesandbox.io/s/sandpack-prettier-1po91?file=/src/App.js
+- Integrate Prettier for code formatting: [CodeSandbox example](https://codesandbox.io/s/sandpack-prettier-1po91?file=/src/App.js)

--- a/website/docs/docs/guides.md
+++ b/website/docs/docs/guides.md
@@ -1,0 +1,8 @@
+---
+sidebar_position: 6
+title: Guides
+---
+
+Here you can find some guides or recipes on using the Sandpack in different situations. These examples are basic implementations, and you need to consider improving for production, but you can find more detailed guides in the [advanced usage](/advanced-usage/provider) section.
+
+- Prettier: https://codesandbox.io/s/sandpack-prettier-1po91?file=/src/App.js


### PR DESCRIPTION
This introduces a new section in the documentation, which is related to guides, recipes, or examples. The idea is to introduce some basics (but very common) implementation, and later we can improve this content by turning them in tutorials.