### PR TITLE
fix(codemirror): shift approach to remove placeholder

### DIFF
--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -228,6 +228,12 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
         });
 
         const parentDiv = wrapper.current;
+        const existingPlaceholder = parentDiv.querySelector(
+          ".sp-pre-placeholder"
+        );
+        if (existingPlaceholder) {
+          parentDiv.removeChild(existingPlaceholder);
+        }
 
         const view = new EditorView({
           state: startState,
@@ -350,9 +356,7 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
     if (readOnly) {
       return (
         <pre ref={combinedRef} className={c("cm", editorState)} translate="no">
-          {!shouldInitEditor && (
-            <code className={c("pre-placeholder")}>{code}</code>
-          )}
+          <code className={c("pre-placeholder")}>{code}</code>
 
           {readOnly && showReadOnly && (
             <span className={c("read-only")}>Read-only</span>
@@ -376,16 +380,14 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
         tabIndex={0}
         translate="no"
       >
-        {!shouldInitEditor && (
-          <pre
-            className={c("pre-placeholder")}
-            style={{
-              marginLeft: showLineNumbers ? 28 : 0, // gutter line offset
-            }}
-          >
-            {code}
-          </pre>
-        )}
+        <pre
+          className={c("pre-placeholder")}
+          style={{
+            marginLeft: showLineNumbers ? 28 : 0, // gutter line offset
+          }}
+        >
+          {code}
+        </pre>
 
         <>
           <p


### PR DESCRIPTION
This shifts the approach used to replace the `placeholder` codebase to the CodeMirror editor. The previous implementation was using a React state which, for a moment, the editor didn't have any codebase at all. From now on, I brought back the previous implementation, which uses DOM API to remove the placeholder in the right moment of the CodeMirror is created, which is way faster than a React DOM flow.