### PR TITLE
Refactor: LoadingOverlay animation transition moved css class

### DIFF
--- a/sandpack-react/src/common/LoadingOverlay.tsx
+++ b/sandpack-react/src/common/LoadingOverlay.tsx
@@ -48,13 +48,7 @@ export const LoadingOverlay: React.FC<LoadingOverlayProps> = ({ clientId }) => {
   }
 
   return (
-    <div
-      className={c("overlay", "loading")}
-      style={{
-        opacity: loadingOverlayState === "visible" ? 1 : 0,
-        transition: "opacity 0.5s ease-out",
-      }}
-    >
+    <div className={c("overlay", "loading", loadingOverlayState)}>
       <div className="sp-cube-wrapper" title="Open in CodeSandbox">
         <OpenInCodeSandboxButton />
         <div className="sp-cube">

--- a/sandpack-react/src/styles/index.css
+++ b/sandpack-react/src/styles/index.css
@@ -28,6 +28,8 @@
   --sp-space-8: 32px;
   --sp-border-radius: 4px;
 
+  --sp-loading-transition: opacity 0.5s ease-out;
+
   all: initial;
 
   font-size: var(--sp-font-size);
@@ -370,7 +372,13 @@
 
 .sp-loading {
   background-color: var(--sp-colors-bg-default);
+  transition: var(--sp-loading-transition);
+  opacity: 0;
   z-index: 5;
+}
+
+.sp-visible {
+  opacity: 1;
 }
 
 .sp-cube-wrapper {

--- a/sandpack-react/src/styles/index.css
+++ b/sandpack-react/src/styles/index.css
@@ -29,6 +29,7 @@
   --sp-border-radius: 4px;
 
   --sp-loading-transition: opacity 0.5s ease-out;
+  --sp-loading-opacity: 0;
 
   all: initial;
 
@@ -373,7 +374,7 @@
 .sp-loading {
   background-color: var(--sp-colors-bg-default);
   transition: var(--sp-loading-transition);
-  opacity: 0;
+  opacity: var(--sp-loading-opacity);
   z-index: 5;
 }
 


### PR DESCRIPTION
## What kind of change does this pull request introduce?

LoadingOverlay component animation transition moved from inline style to CSS class, so it can be changed within styles

## What is the current behavior?

Currently LoadingOverlay component animation transition is hardcoded with div styles and there is no way to change it or remove it

## What is the new behavior?

Same behavior but more flexible setup

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

Storybook

## Checklist

- [x] Ready to be merged
