### PR TITLE
OpenInCodeSandboxButton: preserve ?file= param for big sandboxes

### DIFF
--- a/sandpack-react/src/common/OpenInCodeSandboxButton/UnstyledOpenInCodeSandboxButton.tsx
+++ b/sandpack-react/src/common/OpenInCodeSandboxButton/UnstyledOpenInCodeSandboxButton.tsx
@@ -62,6 +62,14 @@ export const UnstyledOpenInCodeSandboxButton: React.FC<
     sandpack.openInCSBRegisteredRef.current = true;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  
+  const searchParams = new URLSearchParams({
+    parameters: paramsValues,
+    query: new URLSearchParams({
+      file: sandpack.activePath,
+      'from-sandpack': true,
+    }).toString(),
+  });
 
   /**
    * This is a safe limit to avoid too long requests (401),
@@ -75,7 +83,10 @@ export const UnstyledOpenInCodeSandboxButton: React.FC<
         {...props}
       >
         <form ref={formRef} action={CSB_URL} method="POST" target="_blank">
-          <input name="parameters" type="hidden" value={paramsValues} />
+          {Array.from(
+            searchParams,
+            ([k, v]) => <input key={k} name={k} type="hidden" value={v} />,
+          )}
         </form>
         {children}
       </button>
@@ -84,7 +95,7 @@ export const UnstyledOpenInCodeSandboxButton: React.FC<
 
   return (
     <a
-      href={`${CSB_URL}?parameters=${paramsValues}&query=file=${sandpack.activePath}%26from-sandpack=true`}
+      href={`${CSB_URL}?${searchParams.toString()}`}
       rel="noreferrer noopener"
       target="_blank"
       title="Open in CodeSandbox"


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Ensure that the current file stays selected even if the URL is too long and we switch to a form.

## What is the current behavior?

The `file=` param is set only if paramsValues.length < 1500.

## What is the new behavior?

It's consistently set, so the right file is opened in the new sandbox.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

[I wrote this in the GitHub web editor. Hoping to test the sandbox on this PR.]

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation [N/A]
- [ ] Tests [I didn't see any for this feature]
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
