### PR TITLE
fix: standardize components 

### DIFF
--- a/sandpack-react/src/common/ErrorOverlay.tsx
+++ b/sandpack-react/src/common/ErrorOverlay.tsx
@@ -13,21 +13,27 @@ import { classNames } from "../utils/classNames";
 /**
  * @category Components
  */
-export const ErrorOverlay = (): JSX.Element | null => {
+export const ErrorOverlay = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>): JSX.Element | null => {
   const errorMessage = useErrorMessage();
   const c = useClasser(THEME_PREFIX);
 
   if (!errorMessage) {
     return null;
   }
+
   return (
     <div
       className={classNames(
         c("overlay", "error"),
         absoluteClassName,
-        errorClassName
+        errorClassName,
+        className
       )}
       translate="no"
+      {...props}
     >
       <div className={classNames(c("error-message"), errorMessageClassName)}>
         {errorMessage}

--- a/sandpack-react/src/common/Loading.tsx
+++ b/sandpack-react/src/common/Loading.tsx
@@ -75,13 +75,17 @@ const sidesClassNames = css({
   },
 });
 
-export const Loading = (): JSX.Element => {
+export const Loading = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>): JSX.Element => {
   const c = useClasser(THEME_PREFIX);
 
   return (
     <div
-      className={classNames(c("cube-wrapper"), wrapperClassName)}
+      className={classNames(c("cube-wrapper"), wrapperClassName, className)}
       title="Open in CodeSandbox"
+      {...props}
     >
       <OpenInCodeSandboxButton />
       <div className={classNames(c("cube"), cubeClassName)}>

--- a/sandpack-react/src/common/LoadingOverlay.tsx
+++ b/sandpack-react/src/common/LoadingOverlay.tsx
@@ -32,10 +32,14 @@ const loadingClassName = css({
 /**
  * @category Components
  */
-export const LoadingOverlay: React.FC<LoadingOverlayProps> = ({
+export const LoadingOverlay = ({
   clientId,
   loading,
-}) => {
+  className,
+  style,
+  ...props
+}: LoadingOverlayProps &
+  React.HTMLAttributes<HTMLDivElement>): JSX.Element | null => {
   const loadingOverlayState = useLoadingOverlayState(clientId, loading);
   const c = useClasser(THEME_PREFIX);
 
@@ -49,8 +53,10 @@ export const LoadingOverlay: React.FC<LoadingOverlayProps> = ({
         className={classNames(
           c("overlay", "error"),
           absoluteClassName,
-          errorClassName
+          errorClassName,
+          className
         )}
+        {...props}
       >
         <div className={classNames(c("error-message"), errorMessageClassName)}>
           Unable to establish connection with the sandpack bundler. Make sure
@@ -84,12 +90,15 @@ export const LoadingOverlay: React.FC<LoadingOverlayProps> = ({
       className={classNames(
         c("overlay", "loading"),
         absoluteClassName,
-        loadingClassName
+        loadingClassName,
+        className
       )}
       style={{
+        ...style,
         opacity: stillLoading ? 1 : 0,
         transition: `opacity ${FADE_ANIMATION_DURATION}ms ease-out`,
       }}
+      {...props}
     >
       <Loading />
     </div>

--- a/sandpack-react/src/common/RunButton.tsx
+++ b/sandpack-react/src/common/RunButton.tsx
@@ -34,7 +34,7 @@ export const RunButton = ({
         runButtonClassName,
         className
       )}
-      onClick={(event) => {
+      onClick={(event): void => {
         sandpack.runSandpack();
         onClick?.(event);
       }}

--- a/sandpack-react/src/common/RunButton.tsx
+++ b/sandpack-react/src/common/RunButton.tsx
@@ -17,7 +17,11 @@ const runButtonClassName = css({
 /**
  * @category Components
  */
-export const RunButton = (): JSX.Element | null => {
+export const RunButton = ({
+  className,
+  onClick,
+  ...props
+}: React.HTMLAttributes<HTMLButtonElement>): JSX.Element | null => {
   const c = useClasser(THEME_PREFIX);
   const { sandpack } = useSandpack();
 
@@ -27,10 +31,15 @@ export const RunButton = (): JSX.Element | null => {
         c("button"),
         buttonClassName,
         actionButtonClassName,
-        runButtonClassName
+        runButtonClassName,
+        className
       )}
-      onClick={sandpack.runSandpack}
+      onClick={(event) => {
+        sandpack.runSandpack();
+        onClick?.(event);
+      }}
       type="button"
+      {...props}
     >
       <RunIcon />
       Run

--- a/sandpack-react/src/common/Stack.tsx
+++ b/sandpack-react/src/common/Stack.tsx
@@ -14,15 +14,10 @@ export const stackClassName = css({
 /**
  * @category Components
  */
-export const SandpackStack: React.FC<{ customStyle?: React.CSSProperties }> = ({
-  children,
-  customStyle,
-}) => {
+export const SandpackStack: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
+  props
+) => {
   const c = useClasser(THEME_PREFIX);
 
-  return (
-    <div className={classNames(c("stack"), stackClassName)} style={customStyle}>
-      {children}
-    </div>
-  );
+  return <div className={classNames(c("stack"), stackClassName)} {...props} />;
 };

--- a/sandpack-react/src/components/CodeEditor/index.tsx
+++ b/sandpack-react/src/components/CodeEditor/index.tsx
@@ -18,7 +18,7 @@ import { editorClassName } from "./styles";
 
 export type CodeEditorRef = CodeMirrorRef;
 export interface CodeEditorProps {
-  customStyle?: React.CSSProperties;
+  style?: React.CSSProperties;
   showTabs?: boolean;
   showLineNumbers?: boolean;
   showInlineErrors?: boolean;
@@ -65,7 +65,7 @@ export const SandpackCodeEditor = React.forwardRef<
 >(
   (
     {
-      customStyle,
+      style,
       showTabs,
       showLineNumbers = false,
       showInlineErrors = false,
@@ -93,7 +93,7 @@ export const SandpackCodeEditor = React.forwardRef<
     };
 
     return (
-      <SandpackStack customStyle={customStyle}>
+      <SandpackStack style={style}>
         {shouldShowTabs && <FileTabs closableTabs={closableTabs} />}
 
         <div className={classNames(c("code-editor"), editorClassName)}>

--- a/sandpack-react/src/components/CodeViewer/index.tsx
+++ b/sandpack-react/src/components/CodeViewer/index.tsx
@@ -43,6 +43,7 @@ export const SandpackCodeViewer = React.forwardRef<
       code: propCode,
       initMode,
       wrapContent,
+      ...props
     },
     ref
   ) => {
@@ -52,7 +53,7 @@ export const SandpackCodeViewer = React.forwardRef<
     const shouldShowTabs = showTabs ?? sandpack.openPaths.length > 1;
 
     return (
-      <SandpackStack>
+      <SandpackStack {...props}>
         {shouldShowTabs ? <FileTabs /> : null}
 
         <CodeEditor

--- a/sandpack-react/src/components/FileExplorer/index.tsx
+++ b/sandpack-react/src/components/FileExplorer/index.tsx
@@ -17,13 +17,12 @@ const fileExplorerClassName = css({
  */
 export const FileExplorer = ({
   className,
-}: {
-  className?: string;
-}): JSX.Element => {
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>): JSX.Element | null => {
   const { sandpack } = useSandpack();
 
   return (
-    <div className={classNames(fileExplorerClassName, className)}>
+    <div className={classNames(fileExplorerClassName, className)} {...props}>
       <ModuleList
         activePath={sandpack.activePath}
         files={sandpack.files}

--- a/sandpack-react/src/components/FileTabs/index.tsx
+++ b/sandpack-react/src/components/FileTabs/index.tsx
@@ -57,7 +57,12 @@ export interface FileTabsProps {
  *
  * @category Components
  */
-export const FileTabs = ({ closableTabs }: FileTabsProps): JSX.Element => {
+
+export const FileTabs = ({
+  closableTabs,
+  className,
+  ...props
+}: FileTabsProps & React.HTMLAttributes<HTMLDivElement>): JSX.Element => {
   const { sandpack } = useSandpack();
   const c = useClasser(THEME_PREFIX);
 
@@ -104,7 +109,11 @@ export const FileTabs = ({ closableTabs }: FileTabsProps): JSX.Element => {
   };
 
   return (
-    <div className={classNames(c("tabs"), tabsClassName)} translate="no">
+    <div
+      className={classNames(c("tabs"), tabsClassName, className)}
+      translate="no"
+      {...props}
+    >
       <div
         aria-label="Select active file"
         className={classNames(

--- a/sandpack-react/src/components/Navigator/index.tsx
+++ b/sandpack-react/src/components/Navigator/index.tsx
@@ -56,7 +56,9 @@ export interface NavigatorProps {
 export const Navigator = ({
   clientId,
   onURLChange,
-}: NavigatorProps): JSX.Element => {
+  className,
+  ...props
+}: NavigatorProps & React.HTMLAttributes<HTMLDivElement>): JSX.Element => {
   const [baseUrl, setBaseUrl] = React.useState<string>("");
   const { sandpack, dispatch, listen } = useSandpack();
 
@@ -120,7 +122,10 @@ export const Navigator = ({
   };
 
   return (
-    <div className={classNames(c("navigator"), navigatorClassName)}>
+    <div
+      className={classNames(c("navigator"), navigatorClassName, className)}
+      {...props}
+    >
       <button
         aria-label="Go back one page"
         className={classNames(

--- a/sandpack-react/src/components/Preview/index.tsx
+++ b/sandpack-react/src/components/Preview/index.tsx
@@ -78,7 +78,9 @@ export const SandpackPreview = ({
   showSandpackErrorOverlay = true,
   viewportSize = "auto",
   viewportOrientation = "portrait",
-}: PreviewProps): JSX.Element => {
+  className,
+  ...props
+}: PreviewProps & React.HTMLAttributes<HTMLDivElement>): JSX.Element => {
   const { sandpack, listen } = useSandpack();
   const [iframeComputedHeight, setComputedAutoHeight] = React.useState<
     number | null
@@ -133,10 +135,12 @@ export const SandpackPreview = ({
 
   return (
     <SandpackStack
+      className={className}
       style={{
         ...style,
         ...viewportStyle,
       }}
+      {...props}
     >
       {showNavigator ? (
         <Navigator clientId={clientId.current} onURLChange={handleNewURL} />

--- a/sandpack-react/src/components/Preview/index.tsx
+++ b/sandpack-react/src/components/Preview/index.tsx
@@ -27,7 +27,7 @@ export type ViewportSize =
 
 export type ViewportOrientation = "portrait" | "landscape";
 export interface PreviewProps {
-  customStyle?: React.CSSProperties;
+  style?: React.CSSProperties;
   viewportSize?: ViewportSize;
   viewportOrientation?: ViewportOrientation;
   showNavigator?: boolean;
@@ -71,7 +71,7 @@ const previewActionsClassName = css({
  * @category Components
  */
 export const SandpackPreview = ({
-  customStyle,
+  style,
   showNavigator = false,
   showRefreshButton = true,
   showOpenInCodeSandbox = true,
@@ -133,8 +133,8 @@ export const SandpackPreview = ({
 
   return (
     <SandpackStack
-      customStyle={{
-        ...customStyle,
+      style={{
+        ...style,
         ...viewportStyle,
       }}
     >

--- a/sandpack-react/src/components/ReactDevTools/index.tsx
+++ b/sandpack-react/src/components/ReactDevTools/index.tsx
@@ -17,11 +17,12 @@ type DevToolsTheme = "dark" | "light";
 export const SandpackReactDevTools = ({
   clientId,
   theme,
+  className,
   ...props
 }: {
   clientId?: string;
   theme?: DevToolsTheme;
-} & React.HtmlHTMLAttributes<unknown>): JSX.Element | null => {
+} & React.HTMLAttributes<HTMLDivElement>): JSX.Element | null => {
   const { listen, sandpack } = useSandpack();
   const { theme: sandpackTheme } = useSandpackTheme();
   const c = useClasser(THEME_PREFIX);
@@ -71,7 +72,10 @@ export const SandpackReactDevTools = ({
   };
 
   return (
-    <div className={classNames(c("devtools"), devToolClassName)} {...props}>
+    <div
+      className={classNames(c("devtools"), devToolClassName, className)}
+      {...props}
+    >
       <ReactDevTools browserTheme={getBrowserTheme()} />
     </div>
   );

--- a/sandpack-react/src/components/TranspiledCode/index.tsx
+++ b/sandpack-react/src/components/TranspiledCode/index.tsx
@@ -23,7 +23,10 @@ const transpiledCodeClassName = css({
 /**
  * @category Components
  */
-export const SandpackTranspiledCode = (props: CodeViewerProps): JSX.Element => {
+export const SandpackTranspiledCode = ({
+  className,
+  ...props
+}: CodeViewerProps & React.HTMLAttributes<HTMLDivElement>): JSX.Element => {
   const { sandpack } = useSandpack();
   const transpiledCode = useTranspiledCode();
   const c = useClasser(THEME_PREFIX);
@@ -42,7 +45,14 @@ export const SandpackTranspiledCode = (props: CodeViewerProps): JSX.Element => {
   }, []);
 
   return (
-    <div className={classNames(c("transpiled-code"), transpiledCodeClassName)}>
+    <div
+      className={classNames(
+        c("transpiled-code"),
+        transpiledCodeClassName,
+        className
+      )}
+      {...props}
+    >
       {transpiledCode && (
         <SandpackCodeViewer
           code={transpiledCode}

--- a/sandpack-react/src/presets/CustomSandpack.stories.tsx
+++ b/sandpack-react/src/presets/CustomSandpack.stories.tsx
@@ -41,14 +41,14 @@ export const UsingVisualElements: React.FC = () => (
   <SandpackProvider options={{ activePath: "/App.js" }} template="react">
     <SandpackThemeProvider>
       <SandpackCodeEditor
-        customStyle={{
+        style={{
           width: 500,
           height: 300,
         }}
       />
 
       <SandpackPreview
-        customStyle={{
+        style={{
           border: "1px solid red",
           marginBottom: 4,
           marginTop: 4,
@@ -121,7 +121,7 @@ export const UsingHooks: React.FC = () => (
       <CustomCodeEditor />
 
       <SandpackPreview
-        customStyle={{ border: "1px solid red", width: 400, height: 300 }}
+        style={{ border: "1px solid red", width: 400, height: 300 }}
         showOpenInCodeSandbox={false}
         showRefreshButton={false}
       />

--- a/sandpack-react/src/presets/Sandpack.tsx
+++ b/sandpack-react/src/presets/Sandpack.tsx
@@ -64,7 +64,7 @@ export const Sandpack: SandpackPreset = (props) => {
         <SandpackLayout theme={props.theme}>
           <SandpackCodeEditor
             {...codeEditorOptions}
-            customStyle={{
+            style={{
               height: editorHeight,
               flexGrow: editorPart,
               flexShrink: editorPart,
@@ -72,7 +72,7 @@ export const Sandpack: SandpackPreset = (props) => {
             }}
           />
           <SandpackPreview
-            customStyle={{
+            style={{
               height: editorHeight,
               flexGrow: previewPart,
               flexShrink: previewPart,


### PR DESCRIPTION
- Accept className props;
- Rename `customStyle` to `style`;
- Add proper Typescript types based on HTML element;