### PR TITLE
fix: don't make unnecessary sync updates

### DIFF
--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -365,7 +365,9 @@ class SandpackProvider extends React.PureComponent<
      * Watch the changes on editorState
      */
     const editorState = isEqual(files, this.state.files) ? "pristine" : "dirty";
-    this.setState({ editorState });
+    if (editorState !== this.state.editorState) {
+      this.setState({ editorState });
+    }
   }
 
   /**


### PR DESCRIPTION
This is a nested update. Nested updates are bad for performance. They're also always sync, which isn't good for hydration.

In this case the whole pattern is unfortunate. Instead of a nested update, this should use `getDerivedStateFromProps`. But for now, this is an OK workaround that should improve perf.