### PR TITLE
feat: Add logLevel to sandpack options

### DIFF
--- a/sandpack-client/src/client.ts
+++ b/sandpack-client/src/client.ts
@@ -1,5 +1,6 @@
 import { getTemplate } from "codesandbox-import-utils/lib/create-sandbox/templates";
 import isEqual from "lodash.isequal";
+import { SandpackLogLevel } from ".";
 
 import Protocol from "./file-resolver-protocol";
 import { IFrameProtocol } from "./iframe-protocol";
@@ -30,6 +31,10 @@ export interface ClientOptions {
    * Location of the bundler.
    */
   bundlerURL?: string;
+  /**
+   * Level of logging to do in the bundler
+   */
+  logLevel?: SandpackLogLevel;
   /**
    * Relative path that the iframe loads (eg: /about)
    */
@@ -289,6 +294,7 @@ export class SandpackClient {
       showLoadingScreen: this.options.showLoadingScreen ?? true,
       skipEval: this.options.skipEval || false,
       clearConsoleDisabled: !this.options.clearConsoleOnFirstCompile,
+      logLevel: this.options.logLevel,
     });
   }
 

--- a/sandpack-client/src/types.ts
+++ b/sandpack-client/src/types.ts
@@ -30,6 +30,14 @@ export interface ModuleSource {
   sourceMap: unknown | undefined;
 }
 
+export enum SandpackLogLevel {
+  None = 0,
+  Error = 10,
+  Warning = 20,
+  Info = 30,
+  Debug = 40,
+}
+
 export interface ErrorStackFrame {
   columnNumber: number;
   fileName: string;
@@ -175,6 +183,7 @@ export type SandpackMessage = BaseSandpackMessage &
         skipEval: boolean;
         clearConsoleDisabled?: boolean;
         reactDevTools?: ReactDevToolsMode;
+        logLevel?: SandpackLogLevel;
       }
     | {
         type: "refresh";

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -6,6 +6,7 @@ import type {
   SandpackMessage,
   UnsubscribeFunction,
   ReactDevToolsMode,
+  SandpackLogLevel,
 } from "@codesandbox/sandpack-client";
 import {
   SandpackClient,
@@ -72,6 +73,7 @@ export interface SandpackProviderProps {
 
   // bundler options
   bundlerURL?: string;
+  logLevel?: SandpackLogLevel;
   startRoute?: string;
   skipEval?: boolean;
   fileResolver?: FileResolver;
@@ -409,6 +411,7 @@ class SandpackProvider extends React.PureComponent<
       {
         externalResources: this.props.externalResources,
         bundlerURL: this.props.bundlerURL,
+        logLevel: this.props.logLevel,
         startRoute: this.props.startRoute,
         fileResolver: this.props.fileResolver,
         skipEval: this.props.skipEval,


### PR DESCRIPTION
## What kind of change does this pull request introduce?

<!-- Is it a Bug fix, feature, documentation update... -->

## What is the current behavior?

<!-- You can also link to an open issue here -->

There is no way to change the log level from sandpack itself, this is configured mostly using hacks in localstorage or query params

## What is the new behavior?

<!-- if this is a feature change -->

Log level is specified via the options of sandpack (currently only works for the new bundler)

