### PR TITLE
fix: sort decorators before pass to codemirror

### DIFF
--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -147,6 +147,16 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
     const languageExtension = getLanguageFromFile(filePath, fileType);
     const langSupport = getCodeMirrorLanguage(languageExtension);
 
+    // decorators need to be sorted by `line`, otherwise it will throw error
+    // see https://github.com/codesandbox/sandpack/issues/383
+    const sortedDecorators = React.useMemo(
+      () =>
+        decorators
+          ? decorators.sort((d1, d2) => d1.line - d2.line)
+          : decorators,
+      [decorators]
+    );
+
     React.useEffect(() => {
       if (!wrapper.current || !shouldInitEditor) return;
 
@@ -211,8 +221,8 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
           extensionList.push(highlightActiveLine());
         }
 
-        if (decorators) {
-          extensionList.push(highlightDecorators(decorators));
+        if (sortedDecorators) {
+          extensionList.push(highlightDecorators(sortedDecorators));
         }
 
         if (wrapContent) {
@@ -275,7 +285,13 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
 
       // TODO: Would be nice to reconfigure the editor when these change, instead of recreating with all the extensions from scratch
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [shouldInitEditor, showLineNumbers, wrapContent, themeId, decorators]);
+    }, [
+      shouldInitEditor,
+      showLineNumbers,
+      wrapContent,
+      themeId,
+      sortedDecorators,
+    ]);
 
     React.useEffect(() => {
       // When the user clicks on a tab button on a larger screen

--- a/sandpack-react/src/components/CodeViewer/CodeViewer.stories.tsx
+++ b/sandpack-react/src/components/CodeViewer/CodeViewer.stories.tsx
@@ -126,17 +126,17 @@ export default function List() {
             { className: "highlight", line: 9 },
             {
               className: "widget",
-              elementAttributes: { "data-id": "1" },
-              line: 12,
-              startColumn: 26,
-              endColumn: 38,
-            },
-            {
-              className: "widget",
               elementAttributes: { "data-id": "2" },
               line: 13,
               startColumn: 8,
               endColumn: 17,
+            },
+            {
+              className: "widget",
+              elementAttributes: { "data-id": "1" },
+              line: 12,
+              startColumn: 26,
+              endColumn: 38,
             },
           ]}
           showLineNumbers={false}


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Bug fix

## What is the current behavior?

Pass down decorators without sort by line will cause codemirror error.

https://github.com/codesandbox/sandpack/issues/383

## What is the new behavior?

decorators without sort will work fine

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

I did not find component unit tests, so I edit the storybook a little to reproduce this problem, and fix the code to make it work.

## Checklist

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

By the way, is there any plan to add unit tests? I can also do some help if needed.
