### PR TITLE
docs: add monaco editor guide

### DIFF
--- a/website/docs/docs/guides/_category_.json
+++ b/website/docs/docs/guides/_category_.json
@@ -1,0 +1,5 @@
+{
+    "label": "Guides",
+    "position": 8
+  }
+  

--- a/website/docs/docs/guides/guides-overview.md
+++ b/website/docs/docs/guides/guides-overview.md
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 7
-title: Guides
+sidebar_position: 1
+title: Guides Overview
 ---
 
 Here you can find some guides or recipes on using the Sandpack in different situations. These examples are basic implementations, and you need to consider improving for production, but you can find more detailed guides in the [advanced usage](/advanced-usage/provider) section.

--- a/website/docs/docs/guides/guides-overview.md
+++ b/website/docs/docs/guides/guides-overview.md
@@ -5,5 +5,6 @@ title: Guides Overview
 
 Here you can find some guides or recipes on using the Sandpack in different situations. These examples are basic implementations, and you need to consider improving for production, but you can find more detailed guides in the [advanced usage](/advanced-usage/provider) section.
 
+- Integrate [Monaco Editor](../guides/integrate-monaco-editor.md)
 - Integrate Prettier for code formatting: [CodeSandbox example](https://codesandbox.io/s/sandpack-prettier-1po91?file=/src/App.js)
 - Integrate Eslint for static code analysis: [CodeSandbox example](https://codesandbox.io/s/sandpack-eslint-vztlt?file=/src/App.tsx)

--- a/website/docs/docs/guides/integrate-monaco-editor.md
+++ b/website/docs/docs/guides/integrate-monaco-editor.md
@@ -29,8 +29,6 @@ If you are not familiar with the Monaco library this is how a basic `Editor` com
 
 ```jsx
 import React from "react";
-import ReactDOM from "react-dom";
-
 import Editor from "@monaco-editor/react";
 
 function App() {
@@ -42,13 +40,9 @@ function App() {
     />
   );
 }
-
-const rootElement = document.getElementById("root");
-ReactDOM.render(<App />, rootElement);
 ```
 
 Now create a component called `MonacoEditor`, and put the Editor component inside a `SandpackStack`.
-
 This is what the `MonacoEditor` component could look like, you can play with the properties to meet your needs.
 
 ```jsx
@@ -84,9 +78,11 @@ function MonacoEditor() {
 }
 ```
 
-If you are unfamiliar with any of the code below make sure to check the [**Advances Usage**](https://sandpack.codesandbox.io/docs/advanced-usage/provider) section for a better understanding.
+:::info
+If you are unfamiliar with any of the code in this guide make sure to check the [**Advances Usage**](https://sandpack.codesandbox.io/docs/advanced-usage/provider) section for a better understanding.
+:::
 
-Finally, using a `SandpackProvider` you can integrate the `MonacoEditor` component like the following example shows:
+Finally, using a `SandpackProvider` you can integrate the `MonacoEditor` component like the following example:
 
 ```jsx
 export default function MySandpack() {
@@ -98,7 +94,7 @@ export default function MySandpack() {
         }}
       >
         <SandpackLayout theme="dark">
-          <MonacoEditor /> // Your Monaco Editor
+          <MonacoEditor /> // Your Monaco Editor Component
           <SandpackPreview customStyle={{ height: "100vh" }} />
         </SandpackLayout>
       </ClasserProvider>

--- a/website/docs/docs/guides/integrate-monaco-editor.md
+++ b/website/docs/docs/guides/integrate-monaco-editor.md
@@ -88,16 +88,10 @@ Finally, using a `SandpackProvider` you can integrate the `MonacoEditor` compone
 export default function MySandpack() {
   return (
     <SandpackProvider template="react">
-      <ClasserProvider
-        classes={{
-          "sp-layout": "no-border",
-        }}
-      >
-        <SandpackLayout theme="dark">
-          <MonacoEditor /> // Your Monaco Editor Component
-          <SandpackPreview customStyle={{ height: "100vh" }} />
-        </SandpackLayout>
-      </ClasserProvider>
+      <SandpackLayout theme="dark">
+        <MonacoEditor /> // Your Monaco Editor Component
+        <SandpackPreview customStyle={{ height: "100vh" }} />
+      </SandpackLayout>
     </SandpackProvider>
   );
 }

--- a/website/docs/docs/guides/integrate-monaco-editor.md
+++ b/website/docs/docs/guides/integrate-monaco-editor.md
@@ -1,0 +1,110 @@
+---
+sidebar_position: 2
+title: Integrate Monaco Editor
+---
+
+## Introduction
+
+The [monaco-editor](https://microsoft.github.io/monaco-editor/) is a well-known web technology based code editor that powers VS Code.
+This section will guide you on how to use the Monaco Editor in Sandpack
+
+:::info
+If you want to jump right into the code check this [**sandbox example**](https://codesandbox.io/s/sandpack-monaco-integration-citxd)
+:::
+
+## Install the Monaco library
+
+To use Monaco in Sandpack first we need to install the Monaco library by running the following command:
+
+```
+yarn add @monaco-editor/react
+```
+
+This library handles the setup process of the Monaco editor and provides a clean API to interact with Monaco from any React environment.
+Here is the [Github repository](https://github.com/suren-atoyan/monaco-react#readme) if you want to learn more about the library
+
+## Integration
+
+If you are not familiar with the Monaco library this is how a basic `Editor` component looks:
+
+```jsx
+import React from "react";
+import ReactDOM from "react-dom";
+
+import Editor from "@monaco-editor/react";
+
+function App() {
+  return (
+    <Editor
+      height="90vh"
+      defaultLanguage="javascript"
+      defaultValue="// some comment"
+    />
+  );
+}
+
+const rootElement = document.getElementById("root");
+ReactDOM.render(<App />, rootElement);
+```
+
+Now create a component called `MonacoEditor`, and put the Editor component inside a `SandpackStack`.
+
+This is what the `MonacoEditor` component could look like, you can play with the properties to meet your needs.
+
+```jsx
+import Editor from "@monaco-editor/react";
+import {
+  useActiveCode,
+  SandpackStack,
+  FileTabs,
+  useSandpack,
+} from "@codesandbox/sandpack-react";
+import "@codesandbox/sandpack-react/dist/index.css";
+
+function MonacoEditor() {
+  const { code, updateCode } = useActiveCode();
+  const { sandpack } = useSandpack();
+
+  return (
+    <SandpackStack customStyle={{ height: "100vh", margin: 0 }}>
+      <FileTabs />
+      <div style={{ flex: 1, paddingTop: 8, background: "#1e1e1e" }}>
+        <Editor
+          width="100%"
+          height="100%"
+          language="javascript"
+          theme="vs-dark"
+          key={sandpack.activePath}
+          defaultValue={code}
+          onChange={(value) => updateCode(value || "")}
+        />
+      </div>
+    </SandpackStack>
+  );
+}
+```
+
+If you are unfamiliar with any of the code below make sure to check the [**Advances Usage**](https://sandpack.codesandbox.io/docs/advanced-usage/provider) section for a better understanding.
+
+Finally, using a `SandpackProvider` you can integrate the `MonacoEditor` component like the following example shows:
+
+```jsx
+export default function MySandpack() {
+  return (
+    <SandpackProvider template="react">
+      <ClasserProvider
+        classes={{
+          "sp-layout": "no-border",
+        }}
+      >
+        <SandpackLayout theme="dark">
+          <MonacoEditor /> // Your Monaco Editor
+          <SandpackPreview customStyle={{ height: "100vh" }} />
+        </SandpackLayout>
+      </ClasserProvider>
+    </SandpackProvider>
+  );
+}
+```
+
+Congratulations! 🎉 you can now enjoy the Monaco Editor in Sandpack.


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Introduces a guide to integrate Monaco editor in place of the CodeMirror #327 
## What is the current behavior?

Currently we only have one Guides page

## What is the new behavior?

This PR adds a section called Guides, where we can add more guides in the future

## Checklist

- [X] Documentation
- [X] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Let me know if you like this format or if you have any suggestions, thanks 👍.
