### PR TITLE
fix: side effect should contain css

### DIFF
--- a/sandpack-react/package.json
+++ b/sandpack-react/package.json
@@ -12,7 +12,7 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": ["dist/index.css"],
   "scripts": {
     "clean": "rimraf dist",
     "prebuild": "yarn run clean",


### PR DESCRIPTION
## What kind of change does this pull request introduce?

<!-- Is it a Bug fix, feature, documentation update... -->

- bug fix, the `@codesandbox/sandpack-react` package requires users to import the css file (`import "@codesandbox/sandpack-react/dist/index.css"`), which would be removed after tree shaking

## What is the current behavior?

<!-- You can also link to an open issue here -->

-  style from css would be removed after tree shaking

## What is the new behavior?

-  style from css would not be removed after tree shaking

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

- would occur in any projects use `@codesandbox/sanpack-react` using tree shaking


## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
