### PR TITLE
fix(client): prevent add route into the main page browser history

### DIFF
--- a/sandpack-client/src/client.ts
+++ b/sandpack-client/src/client.ts
@@ -157,9 +157,12 @@ export class SandpackClient {
       );
     }
 
-    this.iframe.src = options.startRoute
+    const urlSource = options.startRoute
       ? new URL(options.startRoute, this.bundlerURL).toString()
       : this.bundlerURL;
+
+    this.iframe.contentWindow?.location.replace(urlSource);
+
     this.iframeProtocol = new IFrameProtocol(this.iframe, this.bundlerURL);
 
     this.unsubscribeGlobalListener = this.iframeProtocol.globalListen(

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -499,7 +499,7 @@ class SandpackProvider extends React.PureComponent<
     const client = this.clients[clientId];
     if (client) {
       client.cleanup();
-      client.iframe.removeAttribute("src");
+      client.iframe.contentWindow?.location.replace("about:blank");
       delete this.clients[clientId];
     } else {
       delete this.preregisteredIframes[clientId];


### PR DESCRIPTION
**Problem:** 
The iframe assigns a new URL in a manner that adds a new entry to the browser's list of visited URLs, on Firefox. 

**Solution:** 
So, instead of manipulating the iframe dom and adding/removing the `src` attribute, it manipulates the iframe browser history.

Fixes https://github.com/codesandbox/sandpack/issues/398

Useful links:
- https://github.com/aFarkas/lazysizes/commit/512800de6ebddf6a5000624b67f86c4f0d77d8c6
- [stackoverflow.com/questions/2245883/browser-back-acts-on-nested-iframe-before-the-page-itself-is-there-a-way-to-av](https://stackoverflow.com/questions/2245883/browser-back-acts-on-nested-iframe-before-the-page-itself-is-there-a-way-to-av)