### PR TITLE
feat: Add slot for additional buttons

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,10 +22,11 @@
 <!-- add "N/A" to the end of each line that's irrelevant to your changes -->
 <!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
 
-- [ ] Documentation
-- [ ] Tests
-- [ ] Ready to be merged
-      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
+- [ ] Documentation;
+- [ ] Storybook (if applicable);
+- [ ] Tests;
+- [ ] Ready to be merged;
+
 
 <!-- feel free to add additional comments -->
 <!-- Thank you for contributing! -->

--- a/sandpack-react/src/components/Preview/Preview.stories.tsx
+++ b/sandpack-react/src/components/Preview/Preview.stories.tsx
@@ -1,9 +1,12 @@
 import type { Story } from "@storybook/react";
 import * as React from "react";
 
-import { SandpackLayout } from "../../common/Layout";
-import { SandpackProvider } from "../../contexts/sandpackContext";
-import { SandpackThemeProvider } from "../../contexts/themeContext";
+import {
+  SandpackCodeEditor,
+  SandpackThemeProvider,
+  SandpackProvider,
+  SandpackLayout,
+} from "../../";
 
 import type { PreviewProps } from "./index";
 import { SandpackPreview } from "./index";
@@ -98,5 +101,24 @@ export const AutoResize: React.FC = () => (
     <SandpackThemeProvider>
       <SandpackPreview />
     </SandpackThemeProvider>
+  </SandpackProvider>
+);
+
+export const AdditionalButtons: React.FC = () => (
+  <SandpackProvider template="react">
+    <SandpackLayout>
+      <SandpackPreview
+        actionsChildren={
+          <button
+            className="sp-button"
+            style={{ padding: "var(--sp-space-1) var(--sp-space-3)" }}
+            onClick={() => window.alert("Bug reported!")}
+          >
+            Report bug
+          </button>
+        }
+      />
+      <SandpackCodeEditor />
+    </SandpackLayout>
   </SandpackProvider>
 );

--- a/sandpack-react/src/components/Preview/index.tsx
+++ b/sandpack-react/src/components/Preview/index.tsx
@@ -33,7 +33,7 @@ export interface PreviewProps {
   showOpenInCodeSandbox?: boolean;
   showRefreshButton?: boolean;
   showSandpackErrorOverlay?: boolean;
-  additionalButtons?: JSX.Element;
+  actionsChildren?: JSX.Element;
 }
 
 export { RefreshButton };
@@ -47,7 +47,7 @@ export const SandpackPreview = ({
   showRefreshButton = true,
   showOpenInCodeSandbox = true,
   showSandpackErrorOverlay = true,
-  additionalButtons = <></>,
+  actionsChildren = <></>,
   viewportSize = "auto",
   viewportOrientation = "portrait",
 }: PreviewProps): JSX.Element => {
@@ -132,7 +132,7 @@ export const SandpackPreview = ({
         {showSandpackErrorOverlay ? <ErrorOverlay /> : null}
 
         <div className={c("preview-actions")}>
-          {additionalButtons}
+          {actionsChildren}
           {!showNavigator && showRefreshButton && status === "running" ? (
             <RefreshButton clientId={clientId.current} />
           ) : null}

--- a/sandpack-react/src/components/Preview/index.tsx
+++ b/sandpack-react/src/components/Preview/index.tsx
@@ -1,6 +1,7 @@
 import { useClasser } from "@code-hike/classer";
 import * as React from "react";
 
+import type { SandpackMessage } from "../../../../sandpack-client";
 import { ErrorOverlay } from "../../common/ErrorOverlay";
 import { LoadingOverlay } from "../../common/LoadingOverlay";
 import { OpenInCodeSandboxButton } from "../../common/OpenInCodeSandboxButton";
@@ -60,7 +61,7 @@ export const SandpackPreview = ({
     openInCSBRegisteredRef,
     loadingScreenRegisteredRef,
   } = sandpack;
-
+  
   const c = useClasser("sp");
   const clientId = React.useRef<string>(generateRandomId());
   const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
@@ -77,7 +78,7 @@ export const SandpackPreview = ({
 
     registerBundler(iframeElement, clientIdValue);
 
-    const unsubscribe = listen((message) => {
+    const unsubscribe = listen((message: SandpackMessage) => {
       if (message.type === "resize") {
         setComputedAutoHeight(message.height);
       }

--- a/sandpack-react/src/components/Preview/index.tsx
+++ b/sandpack-react/src/components/Preview/index.tsx
@@ -33,6 +33,7 @@ export interface PreviewProps {
   showOpenInCodeSandbox?: boolean;
   showRefreshButton?: boolean;
   showSandpackErrorOverlay?: boolean;
+  additionalActions?: JSX.Element[];
 }
 
 export { RefreshButton };
@@ -46,6 +47,7 @@ export const SandpackPreview = ({
   showRefreshButton = true,
   showOpenInCodeSandbox = true,
   showSandpackErrorOverlay = true,
+  additionalActions = [],
   viewportSize = "auto",
   viewportOrientation = "portrait",
 }: PreviewProps): JSX.Element => {
@@ -130,6 +132,7 @@ export const SandpackPreview = ({
         {showSandpackErrorOverlay ? <ErrorOverlay /> : null}
 
         <div className={c("preview-actions")}>
+          {...additionalActions}
           {!showNavigator && showRefreshButton && status === "running" ? (
             <RefreshButton clientId={clientId.current} />
           ) : null}

--- a/sandpack-react/src/components/Preview/index.tsx
+++ b/sandpack-react/src/components/Preview/index.tsx
@@ -1,7 +1,7 @@
 import { useClasser } from "@code-hike/classer";
 import * as React from "react";
 
-import type { SandpackMessage } from "../../../../sandpack-client";
+import type { SandpackMessage } from "@codesandbox/sandpack-client";
 import { ErrorOverlay } from "../../common/ErrorOverlay";
 import { LoadingOverlay } from "../../common/LoadingOverlay";
 import { OpenInCodeSandboxButton } from "../../common/OpenInCodeSandboxButton";

--- a/sandpack-react/src/components/Preview/index.tsx
+++ b/sandpack-react/src/components/Preview/index.tsx
@@ -33,7 +33,7 @@ export interface PreviewProps {
   showOpenInCodeSandbox?: boolean;
   showRefreshButton?: boolean;
   showSandpackErrorOverlay?: boolean;
-  additionalActions?: JSX.Element[];
+  additionalButtons?: JSX.Element;
 }
 
 export { RefreshButton };
@@ -47,7 +47,7 @@ export const SandpackPreview = ({
   showRefreshButton = true,
   showOpenInCodeSandbox = true,
   showSandpackErrorOverlay = true,
-  additionalActions = [],
+  additionalButtons = <></>,
   viewportSize = "auto",
   viewportOrientation = "portrait",
 }: PreviewProps): JSX.Element => {
@@ -132,7 +132,7 @@ export const SandpackPreview = ({
         {showSandpackErrorOverlay ? <ErrorOverlay /> : null}
 
         <div className={c("preview-actions")}>
-          {...additionalActions}
+          {additionalButtons}
           {!showNavigator && showRefreshButton && status === "running" ? (
             <RefreshButton clientId={clientId.current} />
           ) : null}

--- a/website/docs/docs/advanced-usage/components.md
+++ b/website/docs/docs/advanced-usage/components.md
@@ -118,7 +118,7 @@ The `<SandpackPreview />` component also allows you to add additional buttons to
 <SandpackProvider template="react">
   <SandpackLayout>
     <SandpackPreview
-      additionalButtons={
+      actionsChildren={
         <button
           className="sp-button"
           style={{ padding: 'var(--sp-space-1) var(--sp-space-3)' }}
@@ -135,7 +135,7 @@ The `<SandpackPreview />` component also allows you to add additional buttons to
 <SandpackProvider template="react">
   <SandpackLayout>
     <SandpackPreview
-      additionalButtons={
+      actionsChildren={
         <button
           className="sp-button"
           style={{ padding: 'var(--sp-space-1) var(--sp-space-3)' }}

--- a/website/docs/docs/advanced-usage/components.md
+++ b/website/docs/docs/advanced-usage/components.md
@@ -122,7 +122,8 @@ The `<SandpackPreview />` component also allows you to add additional buttons to
         <button
           className="sp-button"
           style={{ padding: 'var(--sp-space-1) var(--sp-space-3)' }}
-          onClick={() => window.alert('Bug reported!')}>
+          onClick={() => window.alert('Bug reported!')}
+        >
           Report bug
         </button>
       }
@@ -139,7 +140,8 @@ The `<SandpackPreview />` component also allows you to add additional buttons to
         <button
           className="sp-button"
           style={{ padding: 'var(--sp-space-1) var(--sp-space-3)' }}
-          onClick={() => window.alert('Bug reported!')}>
+          onClick={() => window.alert('Bug reported!')}
+        >
           Report bug
         </button>
       }

--- a/website/docs/docs/advanced-usage/components.md
+++ b/website/docs/docs/advanced-usage/components.md
@@ -111,6 +111,43 @@ There's nothing stopping you from rendering multiple previews in the same `Provi
   </SandpackLayout>
 </SandpackProvider>
 
+## Additional buttons
+The `<SandpackPreview />` component also allows you to add additional buttons to the preview area.
+
+```jsx
+<SandpackProvider template="react">
+  <SandpackLayout>
+    <SandpackPreview
+      additionalButtons={
+        <button
+          className="sp-button"
+          style={{ padding: 'var(--sp-space-1) var(--sp-space-3)' }}
+          onClick={() => window.alert('Bug reported!')}>
+          Report bug
+        </button>
+      }
+    />
+    <SandpackCodeEditor />
+  </SandpackLayout>
+</SandpackProvider>
+```
+
+<SandpackProvider template="react">
+  <SandpackLayout>
+    <SandpackPreview
+      additionalButtons={
+        <button
+          className="sp-button"
+          style={{ padding: 'var(--sp-space-1) var(--sp-space-3)' }}
+          onClick={() => window.alert('Bug reported!')}>
+          Report bug
+        </button>
+      }
+    />
+    <SandpackCodeEditor />
+  </SandpackLayout>
+</SandpackProvider>
+
 ## Code Editor
 
 The `SandpackCodeEditor` component renders a wrapper over [`codemirror`](https://github.com/codemirror/codemirror.next), a lightweight code editor we use inside `sandpack`.

--- a/website/docs/docs/advanced-usage/components.md
+++ b/website/docs/docs/advanced-usage/components.md
@@ -111,7 +111,7 @@ There's nothing stopping you from rendering multiple previews in the same `Provi
   </SandpackLayout>
 </SandpackProvider>
 
-## Additional buttons
+### Additional buttons
 The `<SandpackPreview />` component also allows you to add additional buttons to the preview area.
 
 ```jsx


### PR DESCRIPTION
## What kind of change does this pull request introduce?

This PR enables users to add more buttons to the preview area. They will be rendered right before buttons for "Refresh" and "Open in CodeSandbox".

## What is the current behavior?

Users can't add custom buttons to preview.

## What is the new behavior?

User can add a button in the following way:
```jsx
<SandpackPreview
    additionalButtons={
      <button
        className="sp-button"
        style={{ padding: 'var(--sp-space-1) var(--sp-space-3)' }}
        onClick={() => window.alert('Bug reported!')}>
        Report bug
      </button>
    }
  />
```

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

Manually tested in the documentation and in a personal project.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
