### PR TITLE
fix: Add year and company name to license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@ APPENDIX: How to apply the Apache License to your work.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2022 CodeSandbox BV
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License. You may obtain a copy of the


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/sandpack/DeMoorJasper-patch-1">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=sandpack&branch=DeMoorJasper-patch-1">VS Code</a>

<!-- codesandbox/open-in-codesandbox:complete -->

## What kind of change does this pull request introduce?

Actually adds the company information to the license, as it's probably not really valid right now?
