### PR TITLE
fix(loglevel): set default

### DIFF
--- a/sandpack-client/src/client.ts
+++ b/sandpack-client/src/client.ts
@@ -21,7 +21,7 @@ import {
   extractErrorDetails,
 } from "./utils";
 
-import type { SandpackLogLevel } from ".";
+import { SandpackLogLevel } from ".";
 
 export interface ClientOptions {
   /**
@@ -298,7 +298,7 @@ export class SandpackClient {
       showLoadingScreen: this.options.showLoadingScreen ?? true,
       skipEval: this.options.skipEval || false,
       clearConsoleDisabled: !this.options.clearConsoleOnFirstCompile,
-      logLevel: this.options.logLevel,
+      logLevel: this.options.logLevel || SandpackLogLevel.Debug,
     });
   }
 

--- a/sandpack-client/src/client.ts
+++ b/sandpack-client/src/client.ts
@@ -298,7 +298,7 @@ export class SandpackClient {
       showLoadingScreen: this.options.showLoadingScreen ?? true,
       skipEval: this.options.skipEval || false,
       clearConsoleDisabled: !this.options.clearConsoleOnFirstCompile,
-      logLevel: this.options.logLevel || SandpackLogLevel.Debug,
+      logLevel: this.options.logLevel ?? SandpackLogLevel.Info,
     });
   }
 


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/sandpack/feat/log-level">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=sandpack&branch=feat/log-level">VS Code</a>

<!-- codesandbox/open-in-codesandbox:complete -->

It provides a default value for the `logLevel` on sandpack-client. I see many unexpected logs coming from the bundler that we can't rid of. @DeMoorJasper if someone set `logLevel` to none, will they still receive these logs through iframe-protocol? 