### PR TITLE
feat(preview): consume client 

### DIFF
--- a/sandpack-react/src/components/Preview/Preview.stories.tsx
+++ b/sandpack-react/src/components/Preview/Preview.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../";
 import { useSandpack } from "../../hooks";
 
-import { PreviewProps, SandpackPreviewRef } from "./index";
+import type { PreviewProps, SandpackPreviewRef } from "./index";
 import { SandpackPreview } from "./index";
 
 export default {
@@ -144,6 +144,7 @@ const SandpackClient: React.FC = () => {
     const clientId = previewRef.current?.clientId;
 
     if (client && clientId) {
+      /* eslint-disable no-console */
       console.log(client);
       console.log(sandpack.clients[clientId]);
     }

--- a/sandpack-react/src/components/Preview/Preview.stories.tsx
+++ b/sandpack-react/src/components/Preview/Preview.stories.tsx
@@ -133,3 +133,18 @@ export const AdditionalContent: React.FC = () => (
     </SandpackLayout>
   </SandpackProvider>
 );
+
+export const GetClient: React.FC = () => {
+  const client = React.useRef();
+
+  console.log(client.current);
+
+  return (
+    <SandpackProvider template="react">
+      <SandpackLayout>
+        <SandpackPreview ref={client} />
+        <SandpackCodeEditor />
+      </SandpackLayout>
+    </SandpackProvider>
+  );
+};

--- a/sandpack-react/src/components/Preview/Preview.stories.tsx
+++ b/sandpack-react/src/components/Preview/Preview.stories.tsx
@@ -7,8 +7,9 @@ import {
   SandpackProvider,
   SandpackLayout,
 } from "../../";
+import { useSandpack } from "../../hooks";
 
-import type { PreviewProps } from "./index";
+import { PreviewProps, SandpackPreviewRef } from "./index";
 import { SandpackPreview } from "./index";
 
 export default {
@@ -134,15 +135,26 @@ export const AdditionalContent: React.FC = () => (
   </SandpackProvider>
 );
 
+const SandpackClient: React.FC = () => {
+  const { sandpack } = useSandpack();
+  const previewRef = React.useRef<SandpackPreviewRef>();
+
+  React.useEffect(() => {
+    const client = previewRef.current?.getClient();
+
+    if (client) {
+      console.log(client);
+    }
+  }, [sandpack]);
+
+  return <SandpackPreview ref={previewRef} />;
+};
+
 export const GetClient: React.FC = () => {
-  const client = React.useRef();
-
-  console.log(client.current);
-
   return (
     <SandpackProvider template="react">
       <SandpackLayout>
-        <SandpackPreview ref={client} />
+        <SandpackClient />
         <SandpackCodeEditor />
       </SandpackLayout>
     </SandpackProvider>

--- a/sandpack-react/src/components/Preview/index.tsx
+++ b/sandpack-react/src/components/Preview/index.tsx
@@ -43,7 +43,14 @@ export interface PreviewProps {
 export { RefreshButton };
 
 export interface SandpackPreviewRef {
+  /**
+   * Retrieve the current Sandpack client instance from preview
+   */
   getClient: () => SandpackClient | undefined;
+  /**
+   * Returns the client id, which will be used to
+   * initialize a client in the main Sandpack context
+   */
   clientId: string;
 }
 

--- a/sandpack-react/src/components/Preview/index.tsx
+++ b/sandpack-react/src/components/Preview/index.tsx
@@ -1,5 +1,8 @@
 import { useClasser } from "@code-hike/classer";
-import type { SandpackMessage } from "@codesandbox/sandpack-client";
+import type {
+  SandpackClient,
+  SandpackMessage,
+} from "@codesandbox/sandpack-client";
 import * as React from "react";
 
 import { ErrorOverlay } from "../../common/ErrorOverlay";
@@ -34,120 +37,144 @@ export interface PreviewProps {
   showRefreshButton?: boolean;
   showSandpackErrorOverlay?: boolean;
   actionsChildren?: JSX.Element;
+  children?: JSX.Element;
 }
 
 export { RefreshButton };
 
+interface SandpackPreviewRef {
+  client: SandpackClient | undefined;
+}
+
 /**
  * @category Components
  */
-export const SandpackPreview: React.FC<PreviewProps> = ({
-  customStyle,
-  showNavigator = false,
-  showRefreshButton = true,
-  showOpenInCodeSandbox = true,
-  showSandpackErrorOverlay = true,
-  actionsChildren = <></>,
-  viewportSize = "auto",
-  viewportOrientation = "portrait",
-  children,
-}) => {
-  const { sandpack, listen } = useSandpack();
-  const [iframeComputedHeight, setComputedAutoHeight] = React.useState<
-    number | null
-  >(null);
-  const {
-    status,
-    registerBundler,
-    unregisterBundler,
-    errorScreenRegisteredRef,
-    openInCSBRegisteredRef,
-    loadingScreenRegisteredRef,
-  } = sandpack;
+export const SandpackPreview = React.forwardRef<
+  SandpackPreviewRef,
+  PreviewProps
+>(
+  (
+    {
+      customStyle,
+      showNavigator = false,
+      showRefreshButton = true,
+      showOpenInCodeSandbox = true,
+      showSandpackErrorOverlay = true,
+      actionsChildren = <></>,
+      viewportSize = "auto",
+      viewportOrientation = "portrait",
+      children,
+    },
+    ref
+  ) => {
+    const { sandpack, listen } = useSandpack();
+    const [iframeComputedHeight, setComputedAutoHeight] = React.useState<
+      number | null
+    >(null);
+    const {
+      status,
+      registerBundler,
+      unregisterBundler,
+      errorScreenRegisteredRef,
+      openInCSBRegisteredRef,
+      loadingScreenRegisteredRef,
+    } = sandpack;
 
-  const c = useClasser("sp");
-  const clientId = React.useRef<string>(generateRandomId());
-  const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
+    const c = useClasser("sp");
+    const clientId = React.useRef<string>(generateRandomId());
+    const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
 
-  // SandpackPreview immediately registers the custom screens/components so the bundler does not render any of them
-  openInCSBRegisteredRef.current = true;
-  errorScreenRegisteredRef.current = true;
-  loadingScreenRegisteredRef.current = true;
+    // SandpackPreview immediately registers the custom screens/components so the bundler does not render any of them
+    openInCSBRegisteredRef.current = true;
+    errorScreenRegisteredRef.current = true;
+    loadingScreenRegisteredRef.current = true;
 
-  React.useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const iframeElement = iframeRef.current!;
-    const clientIdValue = clientId.current;
+    React.useEffect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const iframeElement = iframeRef.current!;
+      const clientIdValue = clientId.current;
 
-    registerBundler(iframeElement, clientIdValue);
+      registerBundler(iframeElement, clientIdValue);
 
-    const unsubscribe = listen((message: SandpackMessage) => {
-      if (message.type === "resize") {
-        setComputedAutoHeight(message.height);
+      const unsubscribe = listen((message: SandpackMessage) => {
+        if (message.type === "resize") {
+          setComputedAutoHeight(message.height);
+        }
+      }, clientIdValue);
+
+      return (): void => {
+        unsubscribe();
+        unregisterBundler(clientIdValue);
+      };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    React.useImperativeHandle(
+      ref,
+      () => ({
+        client: sandpack.clients[clientId.current],
+      }),
+      [sandpack.clients]
+    );
+
+    const handleNewURL = (newUrl: string): void => {
+      if (!iframeRef.current) {
+        return;
       }
-    }, clientIdValue);
 
-    return (): void => {
-      unsubscribe();
-      unregisterBundler(clientIdValue);
+      iframeRef.current.src = newUrl;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
-  const handleNewURL = (newUrl: string): void => {
-    if (!iframeRef.current) {
-      return;
-    }
+    const viewportStyle = computeViewportSize(
+      viewportSize,
+      viewportOrientation
+    );
 
-    iframeRef.current.src = newUrl;
-  };
+    return (
+      <SandpackStack
+        customStyle={{
+          ...customStyle,
+          ...viewportStyle,
+        }}
+      >
+        {showNavigator ? (
+          <Navigator clientId={clientId.current} onURLChange={handleNewURL} />
+        ) : null}
 
-  const viewportStyle = computeViewportSize(viewportSize, viewportOrientation);
+        <div className={c("preview-container")}>
+          <iframe
+            ref={iframeRef}
+            className={c("preview-iframe")}
+            style={{
+              // set height based on the content only in auto mode
+              // and when the computed height was returned by the bundler
+              height:
+                viewportSize === "auto" && iframeComputedHeight
+                  ? iframeComputedHeight
+                  : undefined,
+            }}
+            title="Sandpack Preview"
+          />
 
-  return (
-    <SandpackStack
-      customStyle={{
-        ...customStyle,
-        ...viewportStyle,
-      }}
-    >
-      {showNavigator ? (
-        <Navigator clientId={clientId.current} onURLChange={handleNewURL} />
-      ) : null}
+          {showSandpackErrorOverlay ? <ErrorOverlay /> : null}
 
-      <div className={c("preview-container")}>
-        <iframe
-          ref={iframeRef}
-          className={c("preview-iframe")}
-          style={{
-            // set height based on the content only in auto mode
-            // and when the computed height was returned by the bundler
-            height:
-              viewportSize === "auto" && iframeComputedHeight
-                ? iframeComputedHeight
-                : undefined,
-          }}
-          title="Sandpack Preview"
-        />
+          <div className={c("preview-actions")}>
+            {actionsChildren}
+            {!showNavigator && showRefreshButton && status === "running" ? (
+              <RefreshButton clientId={clientId.current} />
+            ) : null}
 
-        {showSandpackErrorOverlay ? <ErrorOverlay /> : null}
+            {showOpenInCodeSandbox ? <OpenInCodeSandboxButton /> : null}
+          </div>
 
-        <div className={c("preview-actions")}>
-          {actionsChildren}
-          {!showNavigator && showRefreshButton && status === "running" ? (
-            <RefreshButton clientId={clientId.current} />
-          ) : null}
+          <LoadingOverlay clientId={clientId.current} />
 
-          {showOpenInCodeSandbox ? <OpenInCodeSandboxButton /> : null}
+          {children}
         </div>
-
-        <LoadingOverlay clientId={clientId.current} />
-
-        {children}
-      </div>
-    </SandpackStack>
-  );
-};
+      </SandpackStack>
+    );
+  }
+);
 
 const VIEWPORT_SIZE_PRESET_MAP: Record<
   ViewportSizePreset,

--- a/sandpack-react/src/components/Preview/index.tsx
+++ b/sandpack-react/src/components/Preview/index.tsx
@@ -42,8 +42,9 @@ export interface PreviewProps {
 
 export { RefreshButton };
 
-interface SandpackPreviewRef {
-  client: SandpackClient | undefined;
+export interface SandpackPreviewRef {
+  getClient: () => SandpackClient | undefined;
+  clientId: string;
 }
 
 /**
@@ -112,9 +113,12 @@ export const SandpackPreview = React.forwardRef<
     React.useImperativeHandle(
       ref,
       () => ({
-        client: sandpack.clients[clientId.current],
+        clientId: clientId.current,
+        getClient(): SandpackClient | undefined {
+          return sandpack.clients[clientId.current];
+        },
       }),
-      [sandpack.clients]
+      [sandpack]
     );
 
     const handleNewURL = (newUrl: string): void => {

--- a/website/docs/docs/advanced-usage/components.md
+++ b/website/docs/docs/advanced-usage/components.md
@@ -183,7 +183,8 @@ const SandpackPreviewClient: React.FC = () => {
 ```
 
 :::note
-Worth mentioning that the SandpackClient will not be instantly available. Sandpack has its own rules to decide what is the "right" moment to initialize an instance from a preview component (take into account properties such as autorun, initMode, and the current client stack priority), which means that it's expected that `getClient` function returns `undefined` and it's a valid state.
+Worth mentioning that the SandpackClient will not be instantly available. Sandpack has its own rules to decide when it'is the "right" moment to initialize an instance from a preview component. (Sandpack will take into account properties such as autorun, initMode, and the current client stack priority) 
+This means that it's expected that `getClient` function returns `undefined` which is a valid state.
 :::
 
 ## Code Editor

--- a/website/docs/docs/advanced-usage/components.md
+++ b/website/docs/docs/advanced-usage/components.md
@@ -153,7 +153,7 @@ The `<SandpackPreview />` component also allows you to add additional buttons to
 ### Additional content
 For advanced use cases, children of `<SandpackPreview>` are rendered at the end of the preview container.
 
-### Getting client instanceSandpackPreviewRef
+### Getting the client instance from SandpackPreview
 
 You can imperatively retrieve the Sandpack client from a SandpackPreview ref, and also consume or interact with the current state of the preview. Check out the [type definitions](/api/react/interfaces/SandpackPreviewRef) for more details.
 

--- a/website/docs/docs/advanced-usage/components.md
+++ b/website/docs/docs/advanced-usage/components.md
@@ -155,7 +155,7 @@ For advanced use cases, children of `<SandpackPreview>` are rendered at the end 
 
 ### Getting client instanceSandpackPreviewRef
 
-You can imperatively retrieve the Sandpack client from a SandpackPreview, consume and interact with the current state of the preview. Check out the [type definitions](/api/react/interfaces/SandpackPreviewRef) for more details.
+You can imperatively retrieve the Sandpack client from a SandpackPreview ref, and also consume or interact with the current state of the preview. Check out the [type definitions](/api/react/interfaces/SandpackPreviewRef) for more details.
 
 ```jsx
 import { SandpackPreviewRef, useSandpack, SandpackPreview } from "@codesandbox/sandpack-react"

--- a/website/docs/docs/advanced-usage/components.md
+++ b/website/docs/docs/advanced-usage/components.md
@@ -153,6 +153,39 @@ The `<SandpackPreview />` component also allows you to add additional buttons to
 ### Additional content
 For advanced use cases, children of `<SandpackPreview>` are rendered at the end of the preview container.
 
+### Getting client instanceSandpackPreviewRef
+
+You can imperatively retrieve the Sandpack client from a SandpackPreview, consume and interact with the current state of the preview. Check out the [type definitions](/api/react/interfaces/SandpackPreviewRef) for more details.
+
+```jsx
+import { SandpackPreviewRef, useSandpack, SandpackPreview } from "@codesandbox/sandpack-react"
+
+const SandpackPreviewClient: React.FC = () => {
+  const { sandpack } = useSandpack();
+  const previewRef = React.useRef<SandpackPreviewRef>();
+
+  React.useEffect(() => {
+    const client = previewRef.current?.getClient();
+    const clientId = previewRef.current?.clientId;
+
+    if (client && clientId) {
+      console.log(client);
+      console.log(sandpack.clients[clientId]);
+    }
+  /**
+   * NOTE: In order to make sure that the client will be available
+   * use the whole `sandpack` object as a dependencie.
+   */
+  }, [sandpack]);
+
+  return <SandpackPreview ref={previewRef} />;
+};
+```
+
+:::note
+Worth mentioning that the SandpackClient will not be instantly available. Sandpack has its own rules to decide what is the "right" moment to initialize an instance from a preview component (take into account properties such as autorun, initMode, and the current client stack priority), which means that it's expected that `getClient` function returns `undefined` and it's a valid state.
+:::
+
 ## Code Editor
 
 The `SandpackCodeEditor` component renders a wrapper over [`codemirror`](https://github.com/codemirror/codemirror.next), a lightweight code editor we use inside `sandpack`.


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/sandpack/preview/client">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=sandpack&branch=preview/client">VS Code</a>

<!-- codesandbox/open-in-codesandbox:complete -->


Imperatively retrieve the Sandpack client from a SandpackPreview:

```jsx
const SandpackClient: React.FC = () => {
  const { sandpack } = useSandpack();
  const previewRef = React.useRef<SandpackPreviewRef>();

  React.useEffect(() => {
    const client = previewRef.current?.getClient();
    const clientId = previewRef.current?.clientId;

    if (client && clientId) {
      console.log(client);
      console.log(sandpack.clients[clientId]);
    }
  }, [sandpack]);

  return <SandpackPreview ref={previewRef} />;
};
```

I agree that currently there is no way to get the current client id and the client instance from a preview component, and it might be too restrictive for a few cases. Although we already have available the list of all clients, currently I can't see a way to link a client from the list to a component, so hope that this new API makes it possible now. 

Worth mentioning, that the SandpackClient will not be instantly available. Sandpack has its own rules to decide what is the "right" moment to initialize a SandpackClient from a preview component (autoron, initMode, client stack), which means that it's expected that `getClient` might return undefined and it's a valid state. 

TODO
- [ ] Tests
- [x] Documentation
- [x] Storybook 

Solves #423 @[malerba118](https://github.com/malerba118) does it make sense for you?