### PR TITLE
fix(theme context component): extend props support

### DIFF
--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -646,12 +646,16 @@ class SandpackProviderClass extends React.PureComponent<
   };
 
   render(): React.ReactElement {
-    const { children, theme } = this.props;
+    const { children, theme, className, style } = this.props;
 
     return (
       <Sandpack.Provider value={this._getSandpackState()}>
         <ClasserProvider classes={this.props.options?.classes}>
-          <SandpackThemeProvider theme={theme}>
+          <SandpackThemeProvider
+            className={className}
+            style={style}
+            theme={theme}
+          >
             {children}
           </SandpackThemeProvider>
         </ClasserProvider>

--- a/sandpack-react/src/contexts/themeContext.tsx
+++ b/sandpack-react/src/contexts/themeContext.tsx
@@ -44,11 +44,13 @@ const SandpackThemeContext = React.createContext<{
 /**
  * @category Theme
  */
-const SandpackThemeProvider: React.FC<{
-  theme?: SandpackThemeProp;
-  children?: React.ReactNode;
-}> = (props) => {
-  const { theme, id } = standardizeTheme(props.theme);
+const SandpackThemeProvider: React.FC<
+  React.HTMLAttributes<HTMLDivElement> & {
+    theme?: SandpackThemeProp;
+    children?: React.ReactNode;
+  }
+> = ({ theme: themeFromProps, children, className, ...props }) => {
+  const { theme, id } = standardizeTheme(themeFromProps);
   const c = useClasser(THEME_PREFIX);
 
   const themeClassName = React.useMemo(() => {
@@ -61,10 +63,12 @@ const SandpackThemeProvider: React.FC<{
         className={classNames(
           c("wrapper"),
           themeClassName.toString(),
-          wrapperClassName
+          wrapperClassName,
+          className
         )}
+        {...props}
       >
-        {props.children}
+        {children}
       </div>
     </SandpackThemeContext.Provider>
   );

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -467,7 +467,8 @@ interface SandpackInternalProps<
 export interface SandpackProviderProps<
   Files extends SandpackFiles = SandpackFiles,
   TemplateName extends SandpackPredefinedTemplate = SandpackPredefinedTemplate
-> extends SandpackRootProps<Files, TemplateName> {
+> extends SandpackRootProps<Files, TemplateName>,
+    React.HTMLAttributes<HTMLDivElement> {
   options?: SandpackInternalOptions<Files, TemplateName>;
   children?: React.ReactNode;
 }

--- a/website/docs/docs/releases/v1.md
+++ b/website/docs/docs/releases/v1.md
@@ -103,7 +103,7 @@ We took this chance to rethink how Sandpack should fit on your website. Our amaz
 From now on `files` , `visibleFiles`, `activeFile` are type-safe:
 
 <video autoPlay muted playsinline>
-  <source src="/img/v1-ts.mp4" type="video/mp4" />
+  <source src="/docs/img/v1-ts.mp4" type="video/mp4" />
 </video>
 
 #### Plus:

--- a/website/landing/components/Hero/HeroDesktop/HeroDesktop.tsx
+++ b/website/landing/components/Hero/HeroDesktop/HeroDesktop.tsx
@@ -292,6 +292,7 @@ export const HeroDesktop: React.FC = () => {
 
         <Box
           css={{
+            color: "$darkTextPrimary",
             fontSize: "calc(100vw / 1920 * 10)",
             fontFamily:
               "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",

--- a/website/landing/components/Intro/Examples.tsx
+++ b/website/landing/components/Intro/Examples.tsx
@@ -5,6 +5,7 @@ import {
   SandpackProvider,
   SandpackThemeProvider,
 } from "@codesandbox/sandpack-react";
+import { styled } from "@stitches/react";
 import { motion, useTransform, useViewportScroll } from "framer-motion";
 import { useLayoutEffect, useRef, useState } from "react";
 
@@ -19,6 +20,10 @@ import { useLayoutExampleContext } from "./Sections/LayoutContext";
 import { TemplateExample } from "./Sections/Template";
 import { ThemeExample } from "./Sections/Theme";
 import { FadeAnimation } from "./Sections/common";
+
+const SandpackProviderStretch = styled(SandpackProvider, {
+  width: "100% !important",
+});
 
 export const Examples: React.FC = () => {
   const { layoutFiles, visibility } = useLayoutExampleContext();
@@ -159,19 +164,19 @@ export const Examples: React.FC = () => {
       >
         <TemplateExample />
 
-        <SandpackProvider>
+        <SandpackProviderStretch>
           <CustomExample />
-        </SandpackProvider>
+        </SandpackProviderStretch>
 
-        <SandpackProvider>
+        <SandpackProviderStretch>
           <EditorExample />
-        </SandpackProvider>
+        </SandpackProviderStretch>
 
         <ThemeExample />
 
-        <SandpackProvider template="react">
+        <SandpackProviderStretch template="react">
           <LayoutExample />
-        </SandpackProvider>
+        </SandpackProviderStretch>
       </List>
     </>
   );


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/sandpack/draft/purple-currying">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=sandpack&branch=draft/purple-currying">VS Code</a>

<!-- codesandbox/open-in-codesandbox:complete -->

