### PR TITLE
fix(codemirror): remove inline props

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "resolutions": {
     "react": "18.1.0",
-    "react-dom": "18.1.0"
+    "react-dom": "18.1.0",
+    "react-test-renderer": "18.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lint-staged": "^10.5.4",
     "package-build-stats": "7.3.6",
     "prettier": "^2.2.1",
-    "react-test-renderer": "^17.0.2",
+    "react-test-renderer": "18.1.0",
     "cypress-real-events": "^1.7.0"
   },
   "resolutions": {

--- a/sandpack-react/src/components/CodeEditor/CodeEditor.stories.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeEditor.stories.tsx
@@ -79,9 +79,25 @@ export const EslintIntegration: React.FC = () => {
   const { lintErrors, lintExtensions } = useSandpackLint();
 
   return (
-    <SandpackProvider template="react">
+    <SandpackProvider
+      customSetup={{
+        files: {
+          "/App.js": `export default function App() {
+  if(true) {
+    useState()
+  }
+  return <h1>Hello World</h1>
+}`,
+        },
+      }}
+      template="react"
+    >
       <SandpackThemeProvider>
-        <SandpackCodeEditor extensions={lintExtensions} id="extensions" />
+        <SandpackCodeEditor
+          extensions={lintExtensions}
+          extensionsKeymap={[]}
+          id="extensions"
+        />
 
         {JSON.stringify(lintErrors)}
       </SandpackThemeProvider>

--- a/sandpack-react/src/components/CodeEditor/CodeEditor.stories.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeEditor.stories.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { autocompletion, completionKeymap } from "@codemirror/autocomplete";
 import type { Story } from "@storybook/react";
 import * as React from "react";
@@ -7,8 +9,10 @@ import { SandpackProvider } from "../../contexts/sandpackContext";
 import { SandpackThemeProvider } from "../../contexts/themeContext";
 import { SandpackPreview } from "../Preview";
 
-import type { CodeEditorProps } from "./index";
-import { SandpackCodeEditor } from "./index";
+import { useSandpackLint } from "./eslint";
+
+import type { CodeEditorProps } from "./";
+import { SandpackCodeEditor } from "./";
 
 export default {
   title: "components/Code Editor",
@@ -70,6 +74,20 @@ export const ExtensionAutocomplete: React.FC = () => (
     </SandpackThemeProvider>
   </SandpackProvider>
 );
+
+export const EslintIntegration: React.FC = () => {
+  const { lintErrors, lintExtensions } = useSandpackLint();
+
+  return (
+    <SandpackProvider template="react">
+      <SandpackThemeProvider>
+        <SandpackCodeEditor extensions={lintExtensions} id="extensions" />
+
+        {JSON.stringify(lintErrors)}
+      </SandpackThemeProvider>
+    </SandpackProvider>
+  );
+};
 
 export const ReadOnly: React.FC = () => {
   return (

--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -21,7 +21,6 @@ import {
 } from "@codemirror/view";
 import type { KeyBinding } from "@codemirror/view";
 import useIntersectionObserver from "@react-hook/intersection-observer";
-import isEqual from "lodash.isequal";
 import * as React from "react";
 
 import { useSandpack } from "../../hooks/useSandpack";
@@ -30,6 +29,7 @@ import type {
   EditorState as SandpackEditorState,
   SandpackInitMode,
 } from "../../types";
+import { shallowEqual } from "../../utils/array";
 import { getFileName } from "../../utils/stringUtils";
 
 import { highlightDecorators } from "./highlightDecorators";
@@ -305,8 +305,8 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
         const view = cmView.current;
 
         const dependenciesAreDiff =
-          !isEqual(prevExtension.current, extensions) ||
-          !isEqual(prevExtensionKeymap.current, extensionsKeymap);
+          !shallowEqual(extensions, prevExtension.current) ||
+          !shallowEqual(extensionsKeymap, prevExtensionKeymap.current);
 
         if (view && dependenciesAreDiff) {
           view.dispatch({

--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -109,8 +109,8 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
       decorators,
       initMode = "lazy",
       id,
-      extensions = [],
-      extensionsKeymap = [],
+      extensions,
+      extensionsKeymap,
     },
     ref
   ) => {
@@ -204,7 +204,7 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
             ...historyKeymap,
             ...commentKeymap,
             ...customCommandsKeymap,
-            ...extensionsKeymap,
+            ...(extensionsKeymap ?? []),
           ] as KeyBinding[]),
           langSupport,
 
@@ -212,7 +212,7 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
 
           getEditorTheme(theme),
           getSyntaxHighlight(theme),
-          ...extensions,
+          ...(extensions ?? []),
         ];
 
         if (readOnly) {
@@ -302,12 +302,14 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
 
         if (view) {
           view.dispatch({
-            effects: StateEffect.appendConfig.of(extensions),
+            effects: StateEffect.appendConfig.of(extensions ?? []),
           });
 
           view.dispatch({
             effects: StateEffect.appendConfig.of(
-              keymap.of([...extensionsKeymap] as unknown as KeyBinding[])
+              keymap.of([
+                ...(extensionsKeymap ?? []),
+              ] as unknown as KeyBinding[])
             ),
           });
         }

--- a/sandpack-react/src/components/CodeEditor/eslint.ts
+++ b/sandpack-react/src/components/CodeEditor/eslint.ts
@@ -1,0 +1,121 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable import/order */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+import type { EditorView } from "@codemirror/view";
+import type { Diagnostic } from "@codemirror/lint";
+import type { Text } from "@codemirror/text";
+import { Linter } from "eslint/lib/linter/linter";
+import React from "react";
+
+const getCodeMirrorPosition = (
+  doc: Text,
+  { line, column }: { line: number; column?: number }
+): number => {
+  return doc.line(line).from + (column ?? 0) - 1;
+};
+
+const linter = new Linter();
+
+// HACK! Eslint requires 'esquery' using `require`, but there's no commonjs interop.
+// because of this it tries to run `esquery.parse()`, while there's only `esquery.default.parse()`.
+// This hack places the functions in the right place.
+const esquery = require("esquery");
+esquery.parse = esquery.default?.parse;
+esquery.matches = esquery.default?.matches;
+
+const reactRules = require("eslint-plugin-react-hooks").rules;
+linter.defineRules({
+  "react-hooks/rules-of-hooks": reactRules["rules-of-hooks"],
+  "react-hooks/exhaustive-deps": reactRules["exhaustive-deps"],
+});
+
+const options = {
+  parserOptions: {
+    ecmaVersion: 12,
+    sourceType: "module",
+    ecmaFeatures: { jsx: true },
+  },
+  rules: {
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
+  },
+};
+
+const runESLint = (
+  doc: Text
+): { errors: any[]; codeMirrorErrors: Diagnostic[] } => {
+  const codeString = doc.toString();
+  const errors = linter.verify(codeString, options) as any[];
+
+  const severity = {
+    1: "warning",
+    2: "error",
+  };
+
+  const codeMirrorErrors = errors
+    .map((error) => {
+      if (!error) return undefined;
+
+      const from = getCodeMirrorPosition(doc, {
+        line: error.line,
+        column: error.column,
+      });
+
+      const to = getCodeMirrorPosition(doc, {
+        line: error.endLine ?? error.line,
+        column: error.endColumn ?? error.column,
+      });
+
+      return {
+        ruleId: error.ruleId,
+        from,
+        to,
+        severity: severity[error.severity],
+        message: error.message,
+      };
+    })
+    .filter(Boolean) as Diagnostic[];
+
+  return {
+    codeMirrorErrors,
+    errors: errors.map((item) => {
+      return {
+        ...item,
+        severity: severity[item.severity],
+      };
+    }),
+  };
+};
+
+type LintDiagnostic = Array<{
+  line: number;
+  column: number;
+  severity: "warning" | "error";
+  message: string;
+}>;
+
+export const useSandpackLint = (): any => {
+  const [lintErrors, setLintErrors] = React.useState<LintDiagnostic>([]);
+  const [lintExtensions, setLintExtensions] = React.useState<any>([]);
+
+  React.useEffect(() => {
+    const loadLinter = async (): Promise<any> => {
+      const { linter } = await import("@codemirror/lint");
+      const onLint = linter(async (props: EditorView) => {
+        const editorState = props.state.doc;
+        const { errors, codeMirrorErrors } = runESLint(editorState);
+        // Ignore parsing or internal linter errors.
+        const isReactRuleError = (error: any): any => error.ruleId != null;
+        setLintErrors(errors.filter(isReactRuleError));
+        return codeMirrorErrors.filter(isReactRuleError);
+      });
+      setLintExtensions([onLint]);
+    };
+
+    loadLinter();
+  }, []);
+
+  return { lintErrors, lintExtensions };
+};

--- a/sandpack-react/src/contexts/sandpackContext.test.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.test.tsx
@@ -1,7 +1,8 @@
 import React from "react";
+import { create } from "react-test-renderer";
+
 import { SandpackProvider } from "./sandpackContext";
 
-import { create } from "react-test-renderer";
 describe(SandpackProvider, () => {
   it("updates a file", () => {
     const root = create(<SandpackProvider template="react" />);

--- a/sandpack-react/src/utils/array.test.ts
+++ b/sandpack-react/src/utils/array.test.ts
@@ -1,0 +1,19 @@
+import { shallowEqual } from "./array";
+
+describe(shallowEqual, () => {
+  it("should be different: when the first array is longer than the second one", () => {
+    expect(shallowEqual(["1", "2"], ["1"])).toBe(false);
+  });
+
+  it("should be different: when the first array is shorter than the second one", () => {
+    expect(shallowEqual(["1"], ["1", "2"])).toBe(false);
+  });
+
+  it("should be different: when an item is different", () => {
+    expect(shallowEqual(["1", "2"], ["1", "3"])).toBe(false);
+  });
+
+  it("should be equal: when both are an empty array", () => {
+    expect(shallowEqual([], [])).toBe(true);
+  });
+});

--- a/sandpack-react/src/utils/array.ts
+++ b/sandpack-react/src/utils/array.ts
@@ -3,5 +3,15 @@
 export const shallowEqual = (a: any[], b: any[]): boolean => {
   if (a.length !== b.length) return false;
 
-  return a.every((item, index) => item === b[index]);
+  let result = true;
+
+  for (let index = 0; index < a.length; index++) {
+    if (a[index] !== b[index]) {
+      result = false;
+
+      break;
+    }
+  }
+
+  return result;
 };

--- a/sandpack-react/src/utils/array.ts
+++ b/sandpack-react/src/utils/array.ts
@@ -1,0 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export const shallowEqual = (a: any[], b: any[]): boolean => {
+  if (a.length !== b.length) return false;
+
+  return a.every((item, index) => item === b[index]);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -19338,7 +19338,7 @@ react-intersection-observer@^8.32.2:
   resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.33.1.tgz#8e6442cac7052ed63056e191b7539e423e7d5c64"
   integrity sha512-3v+qaJvp3D1MlGHyM+KISVg/CMhPiOlO6FgPHcluqHkx4YFCLuyXNlQ/LE6UkbODXlQcLOppfX6UMxCEkUhDLw==
 
-react-is@17.0.2, "react-is@^16.12.0 || ^17.0.0", react-is@^17.0.1, react-is@^17.0.2:
+react-is@17.0.2, react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -19472,14 +19472,6 @@ react-select@^3.2.0:
     react-input-autosize "^3.0.0"
     react-transition-group "^4.3.0"
 
-react-shallow-renderer@^16.13.1:
-  version "16.14.1"
-  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz#bf0d02df8a519a558fd9b8215442efa5c840e124"
-  integrity sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==
-  dependencies:
-    object-assign "^4.1.1"
-    react-is "^16.12.0 || ^17.0.0"
-
 react-shallow-renderer@^16.15.0:
   version "16.15.0"
   resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
@@ -19514,7 +19506,7 @@ react-syntax-highlighter@^13.5.3:
     prismjs "^1.21.0"
     refractor "^3.1.0"
 
-react-test-renderer@18.1.0, react-test-renderer@^17.0.2:
+react-test-renderer@18.1.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.1.0.tgz#35b75754834cf9ab517b6813db94aee0a6b545c3"
   integrity sha512-OfuueprJFW7h69GN+kr4Ywin7stcuqaYAt1g7airM5cUgP0BoF5G5CXsPGmXeDeEkncb2fqYNECO4y18sSqphg==
@@ -20483,14 +20475,6 @@ saxes@^5.0.1:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
-
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 scheduler@^0.22.0:
   version "0.22.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19343,6 +19343,11 @@ react-is@17.0.2, "react-is@^16.12.0 || ^17.0.0", react-is@^17.0.1, react-is@^17.
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.1.0:
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.1.0.tgz#61aaed3096d30eacf2a2127118b5b41387d32a67"
+  integrity sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==
+
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -19475,6 +19480,14 @@ react-shallow-renderer@^16.13.1:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0"
 
+react-shallow-renderer@^16.15.0:
+  version "16.15.0"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
+  integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
+
 react-side-effect@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.1.tgz#66c5701c3e7560ab4822a4ee2742dee215d72eb3"
@@ -19501,15 +19514,14 @@ react-syntax-highlighter@^13.5.3:
     prismjs "^1.21.0"
     refractor "^3.1.0"
 
-react-test-renderer@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-17.0.2.tgz#4cd4ae5ef1ad5670fc0ef776e8cc7e1231d9866c"
-  integrity sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==
+react-test-renderer@18.1.0, react-test-renderer@^17.0.2:
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.1.0.tgz#35b75754834cf9ab517b6813db94aee0a6b545c3"
+  integrity sha512-OfuueprJFW7h69GN+kr4Ywin7stcuqaYAt1g7airM5cUgP0BoF5G5CXsPGmXeDeEkncb2fqYNECO4y18sSqphg==
   dependencies:
-    object-assign "^4.1.1"
-    react-is "^17.0.2"
-    react-shallow-renderer "^16.13.1"
-    scheduler "^0.20.2"
+    react-is "^18.1.0"
+    react-shallow-renderer "^16.15.0"
+    scheduler "^0.22.0"
 
 react-textarea-autosize@^8.3.0, react-textarea-autosize@^8.3.2:
   version "8.3.3"


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/sandpack/fix/extension-inline-prop">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=sandpack&branch=fix/extension-inline-prop">VS Code</a>

<!-- codesandbox/open-in-codesandbox:complete -->

Address https://github.com/reactjs/reactjs.org/issues/4686#issuecomment-1137402613

All `useEffect` which depends on inline default props (`extensions` and `extensionsKeymap`), were constantly being triggered unnecessarily due to these props always returning a new value every time that the parent rerender.  

@gaearon does it make sense? 

----

Note to me: apply these changes on `main` too.