### PR TITLE
fix(theme): set color-scheme css property in theme context

### DIFF
--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -4,6 +4,6 @@ export default {
   title: "Intro/Playground",
 };
 
-export const Main = (): JSaX.Element => {
-  return <Sandpack theme="auto" />;
+export const Main = (): JSX.Element => {
+  return <Sandpack />;
 };

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -4,6 +4,6 @@ export default {
   title: "Intro/Playground",
 };
 
-export const Main = (): JSX.Element => {
-  return <Sandpack />;
+export const Main = (): JSaX.Element => {
+  return <Sandpack theme="auto" />;
 };

--- a/sandpack-react/src/contexts/themeContext.tsx
+++ b/sandpack-react/src/contexts/themeContext.tsx
@@ -11,6 +11,7 @@ import { standardizeTheme } from "../styles";
 import { defaultLight } from "../themes";
 import type { SandpackTheme, SandpackThemeProp } from "../types";
 import { classNames } from "../utils/classNames";
+import { isDarkColor } from "../utils/stringUtils";
 
 const wrapperClassName = css({
   all: "initial",
@@ -21,6 +22,13 @@ const wrapperClassName = css({
   textRendering: "optimizeLegibility",
   WebkitTapHighlightColor: "transparent",
   WebkitFontSmoothing: "subpixel-antialiased",
+
+  variants: {
+    variant: {
+      dark: { colorScheme: "dark" },
+      light: { colorScheme: "light" },
+    },
+  },
 
   "@media screen and (min-resolution: 2dppx)": {
     WebkitFontSmoothing: "antialiased",
@@ -57,13 +65,15 @@ const SandpackThemeProvider: React.FC<
     return createTheme(id, standardizeStitchesTheme(theme));
   }, [theme, id]);
 
+  const isDarkTheme = isDarkColor(theme.colors.surface1);
+
   return (
     <SandpackThemeContext.Provider value={{ theme, id }}>
       <div
         className={classNames(
           c("wrapper"),
           themeClassName.toString(),
-          wrapperClassName,
+          wrapperClassName({ variant: isDarkTheme ? "dark" : "light" }),
           className
         )}
         {...props}

--- a/sandpack-react/src/presets/Sandpack.test.tsx
+++ b/sandpack-react/src/presets/Sandpack.test.tsx
@@ -33,7 +33,7 @@ describe("getSandpackCssText", () => {
       </SandpackProvider>
     );
 
-    expect(getSandpackCssText().length).toBe(3456);
+    expect(getSandpackCssText().length).toBe(3564);
     expect(getSandpackCssText()).not.toContain(componentClassName);
   });
 


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/sandpack/draft/dreamy-hill">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=sandpack&branch=draft/dreamy-hill">VS Code</a>

<!-- codesandbox/open-in-codesandbox:complete -->

It infers the main surface color from the theme and sets the properly `color-scheme: dark | light` in order to make sure the scrollbars have the suitable theme too. 

Closes #489