### PR TITLE
fix(global-listeners): doesn't unsubscribe all listener unexpectedly 

### DIFF
--- a/sandpack-client/src/iframe-protocol.ts
+++ b/sandpack-client/src/iframe-protocol.ts
@@ -102,7 +102,6 @@ export class IFrameProtocol {
     const listenerId = this.channelListenersCount;
     this.channelListeners[listenerId] = listener;
     this.channelListenersCount++;
-
     return (): void => {
       delete this.channelListeners[listenerId];
     };

--- a/sandpack-client/src/iframe-protocol.ts
+++ b/sandpack-client/src/iframe-protocol.ts
@@ -13,7 +13,7 @@ export class IFrameProtocol {
   private globalListenersCount = 0;
 
   // React to messages from the iframe owned by this instance
-  private channelListeners: Record<number, ListenerFunction> = {};
+  public channelListeners: Record<number, ListenerFunction> = {};
   private channelListenersCount = 0;
 
   // Random number to identify this instance of the client when messages are coming from multiple iframes
@@ -102,6 +102,7 @@ export class IFrameProtocol {
     const listenerId = this.channelListenersCount;
     this.channelListeners[listenerId] = listener;
     this.channelListenersCount++;
+
     return (): void => {
       delete this.channelListeners[listenerId];
     };

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -3,6 +3,7 @@ import * as themes from "@codesandbox/sandpack-themes";
 import { useEffect, useState } from "react";
 
 import type { CodeEditorProps } from "./components/CodeEditor";
+import { useSandpack } from "./hooks";
 import { SANDBOX_TEMPLATES } from "./templates";
 
 import {
@@ -12,7 +13,6 @@ import {
   SandpackLayout,
   SandpackFileExplorer,
 } from "./";
-import { useSandpack } from "./hooks";
 
 export default {
   title: "Intro/Playground",

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as themes from "@codesandbox/sandpack-themes";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import type { CodeEditorProps } from "./components/CodeEditor";
-import { useSandpack } from "./hooks";
 import { SANDBOX_TEMPLATES } from "./templates";
 
 import {
@@ -16,18 +15,6 @@ import {
 
 export default {
   title: "Intro/Playground",
-};
-
-const Listerner = () => {
-  const { listen } = useSandpack();
-
-  useEffect(() => {
-    const foo = listen(console.log);
-
-    return () => foo();
-  }, [listen]);
-
-  return null;
 };
 
 export const Main = (): JSX.Element => {
@@ -155,8 +142,6 @@ export const Main = (): JSX.Element => {
               showRefreshButton={config.Options?.showRefreshButton}
             />
           )}
-
-          <Listerner />
         </SandpackLayout>
       </SandpackProvider>
     </div>

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as themes from "@codesandbox/sandpack-themes";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import type { CodeEditorProps } from "./components/CodeEditor";
 import { SANDBOX_TEMPLATES } from "./templates";
@@ -12,9 +12,22 @@ import {
   SandpackLayout,
   SandpackFileExplorer,
 } from "./";
+import { useSandpack } from "./hooks";
 
 export default {
   title: "Intro/Playground",
+};
+
+const Listerner = () => {
+  const { listen } = useSandpack();
+
+  useEffect(() => {
+    const foo = listen(console.log);
+
+    return () => foo();
+  }, [listen]);
+
+  return null;
 };
 
 export const Main = (): JSX.Element => {
@@ -142,6 +155,8 @@ export const Main = (): JSX.Element => {
               showRefreshButton={config.Options?.showRefreshButton}
             />
           )}
+
+          <Listerner />
         </SandpackLayout>
       </SandpackProvider>
     </div>

--- a/sandpack-react/src/contexts/sandpackContext.test.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.test.tsx
@@ -1,15 +1,28 @@
+/**
+ * @jest-environment jsdom
+ */
 import React from "react";
 import { create } from "react-test-renderer";
 
-import { REACT_TEMPLATE } from "..";
+import * as sandpackClient from "@codesandbox/sandpack-client";
 
-import { SandpackProvider } from "./sandpackContext";
+import { REACT_TEMPLATE, SandpackState, SandpackProviderState } from "..";
+
+import { SandpackProvider, SandpackProviderClass } from "./sandpackContext";
+
+const createContext = (): SandpackProviderClass => {
+  const root = create(<SandpackProvider template="react" />);
+  const instance = root.getInstance();
+
+  instance.runSandpack();
+
+  return instance;
+};
 
 describe(SandpackProvider, () => {
   describe("updateFile", () => {
     it("adds a file", () => {
-      const root = create(<SandpackProvider template="react" />);
-      const instance = root.getInstance();
+      const instance = createContext();
 
       instance.addFile({ "new-file.js": "new-content" });
 
@@ -17,8 +30,7 @@ describe(SandpackProvider, () => {
     });
 
     it("deletes a file", () => {
-      const root = create(<SandpackProvider template="react" />);
-      const instance = root.getInstance();
+      const instance = createContext();
 
       instance.deleteFile("/App.js");
 
@@ -32,8 +44,7 @@ describe(SandpackProvider, () => {
     });
 
     it("updates a file", () => {
-      const root = create(<SandpackProvider template="react" />);
-      const instance = root.getInstance();
+      const instance = createContext();
 
       expect(instance.state.files["/App.js"]).toEqual({
         code: `export default function App() {
@@ -48,8 +59,7 @@ describe(SandpackProvider, () => {
     });
 
     it("updates multiples files", () => {
-      const root = create(<SandpackProvider template="react" />);
-      const instance = root.getInstance();
+      const instance = createContext();
 
       instance.updateFile({ "/App.js": "Foo", "/index.js": "Baz" });
 
@@ -58,8 +68,7 @@ describe(SandpackProvider, () => {
     });
 
     it("updates multiples files in a row", () => {
-      const root = create(<SandpackProvider template="react" />);
-      const instance = root.getInstance();
+      const instance = createContext();
 
       instance.updateFile("/App.js", "Foo");
       instance.updateFile("/index.js", "Baz");
@@ -71,15 +80,13 @@ describe(SandpackProvider, () => {
 
   describe("editorState", () => {
     it("should return the same initial state", () => {
-      const root = create(<SandpackProvider template="react" />);
-      const instance = root.getInstance();
+      const instance = createContext();
 
       expect(instance.state.editorState).toBe("pristine");
     });
 
     it("should return a dirty value after updating a file", () => {
-      const root = create(<SandpackProvider template="react" />);
-      const instance = root.getInstance();
+      const instance = createContext();
 
       expect(instance.state.editorState).toBe("pristine");
 
@@ -88,8 +95,7 @@ describe(SandpackProvider, () => {
     });
 
     it("should return a pristine value after reseting files", () => {
-      const root = create(<SandpackProvider template="react" />);
-      const instance = root.getInstance();
+      const instance = createContext();
 
       expect(instance.state.editorState).toBe("pristine");
 
@@ -101,8 +107,7 @@ describe(SandpackProvider, () => {
     });
 
     it("should return a pristine value after reverting a change", () => {
-      const root = create(<SandpackProvider template="react" />);
-      const instance = root.getInstance();
+      const instance = createContext();
       expect(instance.state.editorState).toBe("pristine");
 
       instance.updateFile("/App.js", "Foo");
@@ -111,6 +116,173 @@ describe(SandpackProvider, () => {
       instance.updateFile("/App.js", REACT_TEMPLATE["files"]["/App.js"].code);
 
       expect(instance.state.editorState).toBe("pristine");
+    });
+  });
+
+  describe("listeners", () => {
+    it("sets a listener, but the client hasn't been created yet - no global listener", () => {
+      const instance = createContext();
+
+      // Act: Add listener
+      const mock = jest.fn();
+      instance.addListener(mock, "client-id");
+
+      // Act: Create client
+      instance.registerBundler(document.createElement("iframe"), "client-id");
+
+      // Expect: one pending unsubscribe function
+      expect(
+        Object.keys(instance.unsubscribeClientListeners["client-id"]).length
+      ).toBe(1);
+
+      // Expect: no global listener
+      expect(Object.keys(instance.queuedListeners.global).length).toBe(0);
+
+      // Expect: one client
+      expect(Object.keys(instance.clients)).toEqual(["client-id"]);
+
+      /**
+       * TODO: figure out how to mock SandpackClient and invoke the listener func
+       */
+      // expect(mock).toHaveBeenCalled();
+    });
+
+    it("sets a listener, but the client hasn't been created yet - global listener", () => {
+      const instance = createContext();
+
+      // Act: Add listener
+      const mock = jest.fn();
+      instance.addListener(mock /* , no client-id */);
+
+      // Act: Create client
+      instance.registerBundler(document.createElement("iframe"), "client-id");
+
+      // Expect: one pending unsubscribe function
+      expect(
+        Object.keys(instance.unsubscribeClientListeners["client-id"]).length
+      ).toBe(1);
+
+      // Expect: no global listener
+      expect(Object.keys(instance.queuedListeners.global).length).toBe(1);
+
+      // Expect: one listener in the client
+      expect(
+        Object.keys(
+          instance.clients["client-id"].iframeProtocol.globalListeners
+        ).length
+      ).toBe(1);
+    });
+
+    it("set a listener, but the client has already been created - no global listener", () => {
+      const instance = createContext();
+
+      // Act: Create client
+      instance.registerBundler(document.createElement("iframe"), "client-id");
+
+      // Expect: no pending unsubscribe function
+      expect(
+        Object.keys(instance.unsubscribeClientListeners["client-id"]).length
+      ).toBe(0);
+
+      // Expect: no global listener
+      expect(Object.keys(instance.queuedListeners.global).length).toBe(0);
+
+      // Act: Add listener
+      const mock = jest.fn();
+      instance.addListener(mock, "client-id");
+
+      // Expect: no pending unsubscribe function
+      expect(
+        Object.keys(instance.unsubscribeClientListeners["client-id"]).length
+      ).toBe(0);
+
+      // Expect: no global listener
+      expect(Object.keys(instance.queuedListeners.global).length).toBe(0);
+
+      // Expect: one listener in the client
+      expect(
+        Object.keys(
+          instance.clients["client-id"].iframeProtocol.channelListeners
+        ).length
+      ).toBe(1);
+    });
+
+    it("set a listener, but the client has already been created - global listener", () => {
+      const instance = createContext();
+
+      // Act: Create client
+      instance.registerBundler(document.createElement("iframe"), "client-id");
+
+      // Expect: no pending unsubscribe function
+      expect(
+        Object.keys(instance.unsubscribeClientListeners["client-id"]).length
+      ).toBe(0);
+
+      // Expect: no global listener
+      expect(Object.keys(instance.queuedListeners.global).length).toBe(0);
+
+      // Act: Add listener
+      const mock = jest.fn();
+      instance.addListener(mock /* , no client-id */);
+
+      // Expect: no pending unsubscribe function, because it's a global
+      expect(
+        Object.keys(instance.unsubscribeClientListeners["client-id"]).length
+      ).toBe(0);
+
+      // Expect: one global listener
+      expect(Object.keys(instance.queuedListeners.global).length).toBe(1);
+
+      // Expect: one listener in the client
+      expect(
+        Object.keys(
+          instance.clients["client-id"].iframeProtocol.channelListeners
+        ).length
+      ).toBe(1);
+    });
+
+    it("sets a new listener and then one more client has been created", () => {
+      const instance = createContext();
+
+      // Act: Add listener
+      const mock = jest.fn();
+      instance.addListener(mock, "client-id");
+
+      // Act: Create client
+      instance.registerBundler(document.createElement("iframe"), "client-id");
+
+      // Expect: one pending unsubscribe function
+      expect(
+        Object.keys(instance.unsubscribeClientListeners["client-id"]).length
+      ).toBe(1);
+
+      // Expect: no global listener
+      expect(Object.keys(instance.queuedListeners.global).length).toBe(0);
+
+      // Expect: one listener in the client
+      expect(
+        Object.keys(
+          instance.clients["client-id"].iframeProtocol.channelListeners
+        ).length
+      ).toBe(1);
+
+      // Act: Add one more listener
+      const anotherMock = jest.fn();
+      instance.addListener(anotherMock /* , no client-id */);
+
+      console.log(
+        instance.clients["client-id"].iframeProtocol.channelListenersCount
+      );
+
+      // Expect: one global listener
+      expect(Object.keys(instance.queuedListeners.global).length).toBe(1);
+
+      // Expect: two listener in the client
+      expect(
+        Object.keys(
+          instance.clients["client-id"].iframeProtocol.channelListeners
+        ).length
+      ).toBe(2);
     });
   });
 });


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/sandpack/draft/crazy-ptolemy">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=sandpack&branch=draft/crazy-ptolemy">VS Code</a>

<!-- codesandbox/open-in-codesandbox:complete -->

## What kind of change does this pull request introduce?

<!-- Is it a Bug fix, feature, documentation update... -->
Make sure that all listeners are not unexpectedly discarded when a listener is unsubscribed. 

## What is the current behavior?

<!-- You can also link to an open issue here -->

Issue is described here: https://github.com/reactjs/reactjs.org/issues/4768

## What is the new behavior?

- From now on, `unregisterBundler` is responsible for removing all listeners for a given client;
- An unsubscribing action no longer remove all listeners from the queue;

Closes #513 