### PR TITLE
fix(codemirror): use correct method to indent the code on tab key press

### DIFF
--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -4,8 +4,8 @@ import { closeBrackets, closeBracketsKeymap } from "@codemirror/closebrackets";
 import {
   defaultKeymap,
   indentLess,
+  indentMore,
   deleteGroupBackward,
-  insertTab,
 } from "@codemirror/commands";
 import { commentKeymap } from "@codemirror/comment";
 import { lineNumbers } from "@codemirror/gutter";
@@ -100,7 +100,7 @@ interface CodeMirrorProps {
    */
   id?: string;
   extensions?: Extension[];
-  extensionsKeymap?: Array<readonly KeyBinding[]>;
+  extensionsKeymap?: KeyBinding[];
 }
 
 export interface CodeMirrorRef {
@@ -197,7 +197,7 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
         const customCommandsKeymap: KeyBinding[] = [
           {
             key: "Tab",
-            run: insertTab,
+            run: indentMore,
           },
           {
             key: "Shift-Tab",

--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -197,10 +197,14 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
         const customCommandsKeymap: KeyBinding[] = [
           {
             key: "Tab",
-            run: ({ state, dispatch }): boolean => {
-              indentMore({ state, dispatch });
+            run: (view): boolean => {
+              indentMore(view);
 
-              return false;
+              const customKey = extensionsKeymap.find(
+                ({ key }) => key === "Tab"
+              );
+
+              return customKey?.run(view) ?? true;
             },
           },
           {
@@ -208,7 +212,11 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
             run: ({ state, dispatch }): boolean => {
               indentLess({ state, dispatch });
 
-              return false;
+              const customKey = extensionsKeymap.find(
+                ({ key }) => key === "Shift-Tab"
+              );
+
+              return customKey?.run(view) ?? true;
             },
           },
           {

--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -197,11 +197,19 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
         const customCommandsKeymap: KeyBinding[] = [
           {
             key: "Tab",
-            run: indentMore,
+            run: ({ state, dispatch }): boolean => {
+              indentMore({ state, dispatch });
+
+              return false;
+            },
           },
           {
             key: "Shift-Tab",
-            run: indentLess,
+            run: ({ state, dispatch }): boolean => {
+              indentLess({ state, dispatch });
+
+              return false;
+            },
           },
           {
             key: "Escape",

--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -147,7 +147,7 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
     const ariaId = useGeneratedId(id);
 
     const prevExtension = React.useRef<Extension[]>([]);
-    const prevExtensionKeymap = React.useRef<Array<readonly KeyBinding[]>>([]);
+    const prevExtensionKeymap = React.useRef<KeyBinding[]>([]);
 
     const { isIntersecting } = useIntersectionObserver(wrapper, {
       rootMargin: "600px 0px",

--- a/sandpack-react/src/components/CodeEditor/index.tsx
+++ b/sandpack-react/src/components/CodeEditor/index.tsx
@@ -48,7 +48,7 @@ export interface CodeEditorProps {
   /**
    * Property to register CodeMirror extension keymap.
    */
-  extensionsKeymap?: Array<readonly KeyBinding[]>;
+  extensionsKeymap?: KeyBinding[];
   /**
    * By default, Sandpack generates a random value to use as an id.
    * Use this to override this value if you need predictable values.


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/sandpack/draft/dank-surf">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=sandpack&branch=draft/dank-surf">VS Code</a>

<!-- codesandbox/open-in-codesandbox:complete -->

Hey @joshwcomeau, this PR addresses your bug report about the ability to override the `extensionsKeymap`. Turns out, it was a mistake on our side and we were literally inserting a `tab` instead of regularly indenting the line. So, this should fix your original problem and make the CodeEditor behavior more consistent.

Closes #522