### PR TITLE
fix(react): set react 18 as peer dependencies

### DIFF
--- a/sandpack-react/package.json
+++ b/sandpack-react/package.json
@@ -80,7 +80,7 @@
     "typescript": "4.4.4"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17",
-    "react-dom": "^16.8.0 || ^17"
+    "react": "^16.8.0 || ^17 || ^18",
+    "react-dom": "^16.8.0 || ^17 || ^18"
   }
 }


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/sandpack/draft/compassionate-pike">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=sandpack&branch=draft/compassionate-pike">VS Code</a>

<!-- codesandbox/open-in-codesandbox:complete -->

Hope this makes react 17 and 18 compatible, without any errors.

FIxes #526