### PR TITLE
Update HeroDesktop.tsx to fix link access

### DIFF
--- a/website/landing/components/Hero/HeroDesktop/HeroDesktop.tsx
+++ b/website/landing/components/Hero/HeroDesktop/HeroDesktop.tsx
@@ -318,6 +318,7 @@ export const HeroDesktop: React.FC = () => {
               width: "100%",
               transformOrigin: "top right",
               transform: "scale($scale)",
+              zIndex: 1
             }}
           >
             <Clipboard />


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/psullivan6/sandpack/patch-1?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=psullivan6&repo=sandpack&branch=patch-1">VS Code</a>

<!-- open-in-codesandbox:complete -->


## What kind of change does this pull request introduce?

Tiny CSS layout bug fix

## What is the current behavior?

On a larger monitor (3377 x 1304) the description overlaps the top links, making it impossible to interact with the links. This can be "resolved" by scrolling down the page, but they're not interactive on initial load.

## What is the new behavior?

Added a `z-index` CSS property to the parent container of the interactive content to ensure it's above the description and thus interactive.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Added the same CSS in the browser dev tools and was able to resolve the issue
2. Removed the CSS in the browser dev tools and was able to see the issue re-appear

## Checklist

- [ ] Documentation; N/A
- [ ] Storybook (if applicable); N/A
- [x] Tests;
- [x] Ready to be merged;

## Changelog

- added `zIndex: 1` to the parent container of the header links to ensure they are interactive. This specifically targets larger screen sizes where the description overlaps the `Clipboard` and `Resources` content