### PR TITLE
fix(client): custom registry should include the credentials only for csb urls 

### DIFF
--- a/sandpack-client/.bundler
+++ b/sandpack-client/.bundler
@@ -1,3 +1,3 @@
 // Manually generated file to trigger new releases based on the bundler changes. 
 // The following value is the commit hash from codesandbox-client
-5712eae0c97f625d9390fa71266280a88e4f9fad
+c758886ab802f7e2fe3aa46f0b8d4c12364fe3ce

--- a/sandpack-react/src/presets/CustomSandpack.stories.tsx
+++ b/sandpack-react/src/presets/CustomSandpack.stories.tsx
@@ -429,7 +429,7 @@ export const CustomNpmRegistries: React.FC = () => (
         {
           enabledScopes: ["@codesandbox"],
           limitToScopes: true,
-          registryUrl: "https://7khir3-4000.preview.csb.app",
+          registryUrl: "https://xywctu-4000.preview.csb.app",
         },
       ],
     }}


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/sandpack/draft/stupefied-feather?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=sandpack&branch=draft/stupefied-feather">VS Code</a>

<!-- open-in-codesandbox:complete -->


