### PR TITLE
feat: Add `initialCursor` to code editor when setting the active file

### DIFF
--- a/sandpack-react/src/components/CodeEditor/index.tsx
+++ b/sandpack-react/src/components/CodeEditor/index.tsx
@@ -94,7 +94,7 @@ export const SandpackCodeEditor = React.forwardRef<
   ) => {
     const { sandpack } = useSandpack();
     const { code, updateCode, readOnly: readOnlyFile } = useActiveCode();
-    const { activeFile, status, editorState } = sandpack;
+    const { activeFile, initialCursor, status, editorState } = sandpack;
     const shouldShowTabs = showTabs ?? sandpack.visibleFiles.length > 1;
 
     const c = useClasser(THEME_PREFIX);
@@ -117,6 +117,7 @@ export const SandpackCodeEditor = React.forwardRef<
             extensionsKeymap={extensionsKeymap}
             filePath={activeFile}
             id={id}
+            initialCursor={initialCursor}
             initMode={initMode || sandpack.initMode}
             onCodeUpdate={handleCodeUpdate}
             readOnly={readOnly || readOnlyFile}

--- a/sandpack-react/src/components/Tests/FormattedError.tsx
+++ b/sandpack-react/src/components/Tests/FormattedError.tsx
@@ -2,6 +2,7 @@ import type { TestError } from "@codesandbox/sandpack-client";
 import * as React from "react";
 
 import { css } from "../../styles";
+import { buttonClassName } from "../../styles/shared";
 import { classNames } from "../../utils/classNames";
 
 import {
@@ -9,6 +10,7 @@ import {
   passTextClassName,
   titleTextClassName,
 } from "./style";
+import { ReactStringReplacer } from "./utils";
 
 interface Props {
   error: TestError;
@@ -22,13 +24,142 @@ const containerClassName = css({
   whiteSpace: "pre-wrap",
 });
 
+const matcherClassName = css({
+  color: "$colors$hover",
+  fontWeight: "bold",
+  textDecorationStyle: "dotted",
+  textDecorationLine: "underline",
+});
+
+const makeMargin = (length: number): string =>
+  Array.from({ length }, () => " ").join("");
+
 export const FormattedError: React.FC<Props> = ({ error, path }) => {
-  return (
-    <div
-      className={classNames(containerClassName)}
-      dangerouslySetInnerHTML={{ __html: formatDiffMessage(error, path) }}
-    />
-  );
+  if (!error.matcherResult) {
+    return (
+      <div
+        className={classNames(containerClassName)}
+        dangerouslySetInnerHTML={{ __html: escapeHtml(error.message) }}
+      />
+    );
+  } else {
+    const matcherResult = new ReactStringReplacer(error.message)
+      .replace(/(expected)/m, (match) => (
+        <span className={passTextClassName}>{match}</span>
+      ))
+      .replace(/(received)/m, (match) => (
+        <span className={failTextClassName}>{match}</span>
+      ))
+      .replace(/(Difference)/m, (match) => <span>{match}</span>)
+      .replace(/((?<=Expected:\s).*)/m, (match) => (
+        <span className={passTextClassName}>{match}</span>
+      ))
+      .replace(/((?<=Received:\s).*)/m, (match) => (
+        <span className={failTextClassName}>{match}</span>
+      ))
+      .replace(/^(-.*)/gm, (match) => (
+        <span className={passTextClassName}>{match}</span>
+      ))
+      .replace(/^(\+.*)/gm, (match) => (
+        <span className={failTextClassName}>{match}</span>
+      ))
+      .replace(/(\n)/gm, () => <br />)
+      .get();
+
+    let mappedErrors: React.ReactNode = null;
+
+    if (
+      error.mappedErrors &&
+      error.mappedErrors[0] &&
+      error.mappedErrors[0].fileName.endsWith(path) &&
+      error.mappedErrors[0]._originalScriptCode
+    ) {
+      const mappedError = error.mappedErrors[0];
+      const _originalScriptCode = mappedError._originalScriptCode || [];
+      const widestNumber =
+        Math.max(
+          ..._originalScriptCode.map(
+            (code) => code.lineNumber.toString().length
+          )
+        ) + 2;
+
+      mappedErrors = _originalScriptCode.map((code) => {
+        const lineNumber = code.lineNumber.toString();
+        const margin = makeMargin(widestNumber - lineNumber.length);
+        const matcherColumn = code.content.indexOf(".to") + 1;
+
+        const content = new ReactStringReplacer(code.content)
+          .match(
+            /(expect\()(.*)(\)\..*)(to[\w\d]*)(\()(.*)(\))/m,
+            ([$0, $1, $2, $3, $4, $5, $6, $7, $8]) => (
+              <>
+                <span>{$0}</span>
+                <span>{$1}</span>
+                <span className={failTextClassName}>{$2}</span>
+                <span>{$3}</span>
+                <span className={classNames(matcherClassName)}>{$4}</span>
+                <span>{$5}</span>
+                <span className={passTextClassName}>{$6}</span>
+                <span>{$7}</span>
+                <span>{$8}</span>
+              </>
+            )
+          )
+          .match(
+            /(describe|test|it)(\()("|'|`)(.*)("|'|`)/m,
+            ([$0, $1, $2, $3, $4, $5, $6]) => (
+              <>
+                <span>
+                  {$0}
+                  {$1}
+                  {$2}
+                  {$3}
+                </span>
+                <span className={titleTextClassName}>{$4}</span>
+                <span>{$5}</span>
+                <span>{$6}</span>
+              </>
+            )
+          );
+
+        return (
+          <>
+            <div style={{ fontWeight: code.highlight ? `200` : `` }}>
+              {code.highlight ? (
+                <span className={failTextClassName}>
+                  &gt; {makeMargin(margin.length - 2)}
+                </span>
+              ) : (
+                margin
+              )}
+              {lineNumber}
+              {" | "}
+              {content.get()}
+            </div>
+            {code.highlight && (
+              <div>
+                {makeMargin(margin.length + lineNumber.length)}
+                {" | "}
+                {makeMargin(matcherColumn)}
+                <span className={failTextClassName}>^</span>
+              </div>
+            )}
+          </>
+        );
+      });
+    }
+
+    return (
+      <div className={classNames(containerClassName)}>
+        <span>{matcherResult}</span>
+        <div>
+          <br />
+          <br />
+          {mappedErrors}
+        </div>
+      </div>
+    );
+  }
 };
 
 const escapeHtml = (unsafe: string): string => {
@@ -38,99 +169,4 @@ const escapeHtml = (unsafe: string): string => {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#039;");
-};
-
-const formatDiffMessage = (error: TestError, path: string): string => {
-  let finalMessage = "";
-  if (error.matcherResult) {
-    finalMessage = `<span>${escapeHtml(error.message)
-      .replace(/(expected)/m, `<span class="${passTextClassName}">$1</span>`)
-      .replace(/(received)/m, `<span class="${failTextClassName}">$1</span>`)
-      .replace(/(Difference:)/m, `<span>$1</span>`)
-      .replace(
-        /(Expected:)(.*)/m,
-        `<span>$1</span><span class="${passTextClassName}">$2</span>`
-      )
-      .replace(
-        /(Received:)(.*)/m,
-        `<span>$1</span><span class="${failTextClassName}">$2</span>`
-      )
-      .replace(/^(-.*)/gm, `<span class="${failTextClassName}">$1</span>`)
-      .replace(
-        /^(\+.*)/gm,
-        `<span class="${passTextClassName}">$1</span>`
-      )}</span>`;
-  } else {
-    finalMessage = escapeHtml(error.message);
-  }
-
-  if (
-    error.mappedErrors &&
-    error.mappedErrors[0] &&
-    error.mappedErrors[0].fileName.endsWith(path) &&
-    error.mappedErrors[0]._originalScriptCode
-  ) {
-    const mappedError = error.mappedErrors[0];
-
-    const _originalScriptCode = mappedError._originalScriptCode || [];
-
-    const widestNumber =
-      Math.max(
-        ..._originalScriptCode.map((code) => (code.lineNumber + "").length)
-      ) + 2;
-
-    const margin = Array.from({ length: widestNumber }).map(() => " ");
-
-    finalMessage += "<br />";
-    finalMessage += "<br />";
-    finalMessage += "<div>";
-    _originalScriptCode
-      .filter((s) => s.content.trim())
-      .forEach((code) => {
-        const currentLineMargin = (code.lineNumber + "").length;
-        const newMargin = [...margin];
-        newMargin.length -= currentLineMargin;
-        if (code.highlight) {
-          newMargin.length -= 2;
-        }
-
-        const toBeIndex = code.content.indexOf(".to");
-        const toBeMargin = Array.from(
-          { length: margin.length + toBeIndex - (widestNumber - 1) },
-          () => " "
-        );
-
-        const content = escapeHtml(code.content)
-          .replace(
-            /(describe|test|it)(\()(&#039;|&quot;|`)(.*)(&#039;|&quot;|`)/m,
-            `<span>$1$2$3</span><span class="${titleTextClassName}">$4</span><span>$5</span>`
-          )
-          .replace(
-            /(expect\()(.*)(\)\..*)(to[\w\d]*)(\()(.*)(\))/m,
-            `<span>$1</span><span class="${failTextClassName}">$2</span><span>$3</span><span style="text-decoration: underline; font-weight: 900">$4</span><span>$5</span><span class="${passTextClassName}">$6</span><span>$7</span>`
-          );
-
-        finalMessage +=
-          `<div ${code.highlight ? `style="font-weight:200;"` : ``}>` +
-          (code.highlight
-            ? `<span class="${failTextClassName}">></span> `
-            : "") +
-          newMargin.join("") +
-          escapeHtml("" + code.lineNumber) +
-          " | " +
-          content +
-          "</div>" +
-          (code.highlight
-            ? "<div>" +
-              margin.join("") +
-              " | " +
-              toBeMargin.join("") +
-              `<span class="${failTextClassName}">^</span>` +
-              "</div>"
-            : "");
-      });
-    finalMessage += "</div>";
-  }
-
-  return finalMessage.replace(/(?:\r\n|\r|\n)/g, "<br />");
 };

--- a/sandpack-react/src/components/Tests/FormattedError.tsx
+++ b/sandpack-react/src/components/Tests/FormattedError.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 
 import { css } from "../../styles";
 import { buttonClassName } from "../../styles/shared";
+import type { Cursor } from "../../types";
 import { classNames } from "../../utils/classNames";
 
 import {
@@ -15,6 +16,7 @@ import { ReactStringReplacer } from "./utils";
 interface Props {
   error: TestError;
   path: string;
+  openSpec: (cursor: Cursor) => void;
 }
 
 const containerClassName = css({
@@ -22,6 +24,13 @@ const containerClassName = css({
   fontSize: "$font$size",
   padding: "$space$2",
   whiteSpace: "pre-wrap",
+});
+
+const matcherButtonClassName = css({
+  fontFamily: "$font$mono",
+  cursor: "pointer",
+  display: "inline-block",
+  padding: "0",
 });
 
 const matcherClassName = css({
@@ -34,7 +43,7 @@ const matcherClassName = css({
 const makeMargin = (length: number): string =>
   Array.from({ length }, () => " ").join("");
 
-export const FormattedError: React.FC<Props> = ({ error, path }) => {
+export const FormattedError: React.FC<Props> = ({ error, path, openSpec }) => {
   if (!error.matcherResult) {
     return (
       <div
@@ -97,7 +106,17 @@ export const FormattedError: React.FC<Props> = ({ error, path }) => {
                 <span>{$1}</span>
                 <span className={failTextClassName}>{$2}</span>
                 <span>{$3}</span>
-                <span className={classNames(matcherClassName)}>{$4}</span>
+                <button
+                  className={classNames(
+                    buttonClassName,
+                    matcherButtonClassName
+                  )}
+                  onClick={(): void =>
+                    openSpec({ line: code.lineNumber, column: matcherColumn })
+                  }
+                >
+                  <span className={classNames(matcherClassName)}>{$4}</span>
+                </button>
                 <span>{$5}</span>
                 <span className={passTextClassName}>{$6}</span>
                 <span>{$7}</span>

--- a/sandpack-react/src/components/Tests/SandpackTests.tsx
+++ b/sandpack-react/src/components/Tests/SandpackTests.tsx
@@ -4,6 +4,7 @@ import { SandpackStack } from "../../common";
 import { Loading } from "../../common/Loading";
 import { useSandpackTheme, useSandpackClient } from "../../hooks";
 import { css, THEME_PREFIX } from "../../styles";
+import type { Cursor } from "../../types";
 import { classNames } from "../../utils/classNames";
 
 import { Header } from "./Header";
@@ -359,8 +360,8 @@ export const SandpackTests: React.FC<
     [runSpec, runAllTests, state.watchMode, isSpecOpen]
   );
 
-  const openSpec = (file: string): void => {
-    sandpack.setActiveFile(file);
+  const openSpec = (file: string, cursor?: Cursor): void => {
+    sandpack.setActiveFile(file, cursor);
   };
 
   const specs = Object.values(state.specs);

--- a/sandpack-react/src/components/Tests/Specs.tsx
+++ b/sandpack-react/src/components/Tests/Specs.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 
 import { css } from "../../styles";
 import { buttonClassName } from "../../styles/shared";
+import type { Cursor } from "../../types";
 import { classNames } from "../../utils/classNames";
 
 import type { Describe } from "./Describes";
@@ -24,7 +25,7 @@ interface Props {
   specs: Spec[];
   verbose: boolean;
   status: Status;
-  openSpec: (name: string) => void;
+  openSpec: (name: string, cursor?: Cursor) => void;
 }
 
 const fileContainer = css({
@@ -93,7 +94,11 @@ export const Specs: React.FC<Props> = ({
                 onClick={(): void => openSpec(spec.name)}
                 path={spec.name}
               />
-              <FormattedError error={spec.error} path={spec.name} />
+              <FormattedError
+                error={spec.error}
+                openSpec={(cursor): void => openSpec(spec.name, cursor)}
+                path={spec.name}
+              />
             </div>
           );
         }
@@ -162,6 +167,7 @@ export const Specs: React.FC<Props> = ({
                     <FormattedError
                       key={`failing-${test.name}-error`}
                       error={e}
+                      openSpec={(cursor): void => openSpec(spec.name, cursor)}
                       path={test.path}
                     />
                   ))}

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -19,6 +19,7 @@ import type {
   SandpackInternalProvider,
   SandpackProviderState,
   SandpackProviderProps,
+  Cursor,
 } from "../types";
 import {
   convertedFilesToBundlerFiles,
@@ -75,6 +76,7 @@ export class SandpackProviderClass extends React.PureComponent<
       visibleFiles,
       visibleFilesFromProps: visibleFiles,
       activeFile,
+      initialCursor: undefined,
       startRoute: this.props.options?.startRoute,
       bundlerState: undefined,
       error: null,
@@ -463,8 +465,8 @@ export class SandpackProviderClass extends React.PureComponent<
     }
   };
 
-  setActiveFile = (activeFile: string): void => {
-    this.setState({ activeFile });
+  setActiveFile = (activeFile: string, initialCursor?: Cursor): void => {
+    this.setState({ activeFile, initialCursor });
   };
 
   openFile = (path: string): void => {
@@ -616,6 +618,7 @@ export class SandpackProviderClass extends React.PureComponent<
     const {
       files,
       activeFile,
+      initialCursor: initialSelection,
       visibleFiles,
       visibleFilesFromProps,
       startRoute,
@@ -633,6 +636,7 @@ export class SandpackProviderClass extends React.PureComponent<
       visibleFiles,
       visibleFilesFromProps,
       activeFile,
+      initialCursor: initialSelection,
       startRoute,
       error,
       bundlerState,

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -618,7 +618,7 @@ export class SandpackProviderClass extends React.PureComponent<
     const {
       files,
       activeFile,
-      initialCursor: initialSelection,
+      initialCursor,
       visibleFiles,
       visibleFilesFromProps,
       startRoute,
@@ -636,7 +636,7 @@ export class SandpackProviderClass extends React.PureComponent<
       visibleFiles,
       visibleFilesFromProps,
       activeFile,
-      initialCursor: initialSelection,
+      initialCursor,
       startRoute,
       error,
       bundlerState,

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -532,6 +532,7 @@ export interface SandpackState {
    * when the component mounts
    */
   activeFile: string;
+  initialCursor?: Cursor;
   startRoute?: string;
 
   /**
@@ -556,7 +557,7 @@ export interface SandpackState {
   openFile: (path: string) => void;
   closeFile: (path: string) => void;
   deleteFile: (path: string) => void;
-  setActiveFile: (path: string) => void;
+  setActiveFile: (path: string, cursor?: Cursor) => void;
   resetFile: (path: string) => void;
   resetAllFiles: () => void;
   registerReactDevTools: (value: ReactDevToolsMode) => void;
@@ -641,6 +642,13 @@ export interface FileResolver {
   isFile: (path: string) => Promise<boolean>;
   readFile: (path: string) => Promise<string>;
 }
+/**
+ * @hidden
+ */
+export interface Cursor {
+  line: number;
+  column: number;
+}
 
 /**
  * @hidden
@@ -653,6 +661,7 @@ export interface SandpackProviderState {
     TemplateFiles<SandpackPredefinedTemplate> | string
   >;
   activeFile: TemplateFiles<SandpackPredefinedTemplate> | string;
+  initialCursor?: Cursor;
   startRoute?: string;
   initMode: SandpackInitMode;
   bundlerState?: BundlerState;


### PR DESCRIPTION
## What kind of change does this pull request introduce?

This PR closes https://github.com/codesandbox/sandpack/issues/558

<!-- Is it a Bug fix, feature, documentation update... -->

## What is the current behavior?

Currently sandpack has a `setActiveFile` function that can only open the file without putting the cursor at a given position.

<!-- You can also link to an open issue here -->

## What is the new behavior?

This PR adds an optional `cursor` (line / column numbers) to the `setActiveFile` function. If a cursor position is set as part of this function then the `CodeMirror` state has a selection at the given cursor and will scroll it into view and focus the editor.

This PR also introduces a change to `SandpackTests`. I've rewritten the `FormattedErrors` component to use JSX instead of relying of string manipulation and dangerously rendering the string. The reason to do this is so that we can safely attach an `onClick` to the failing matcher error which will open the test file at the correct position to fix the matcher.

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

See attached demo of the cursor change in action using `SandpackTests` errors.

https://user-images.githubusercontent.com/5610087/188724977-099ca5d5-b5cc-43a0-b45d-9cd9420a6968.mov



## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation;
- [x] Storybook (if applicable);
- [ ] Tests;
- [ ] Ready to be merged;

## Todo

- I'm going to hold off updating the docs until @danilowoz has had a chance to look this over and he's happy with everything I'll get the docs updated too.

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
