### PR TITLE
fix(client-navigation): make sure iframe is using the right location on refreshing 

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
   "packages": ["sandpack-client", "sandpack-react"],
-  "sandboxes": ["sowx8r", "c3uup0"],
+  "sandboxes": ["sowx8r", "p9l5gn"],
   "node": "14"
 }

--- a/sandpack-client/src/client.ts
+++ b/sandpack-client/src/client.ts
@@ -166,11 +166,7 @@ export class SandpackClient {
       );
     }
 
-    const urlSource = options.startRoute
-      ? new URL(options.startRoute, this.bundlerURL).toString()
-      : this.bundlerURL;
-
-    this.iframe.contentWindow?.location.replace(urlSource);
+    this.setLocationURLIntoIFrame();
 
     this.iframeProtocol = new IFrameProtocol(this.iframe, this.bundlerURL);
 
@@ -228,6 +224,14 @@ export class SandpackClient {
         }
       }
     );
+  }
+
+  public setLocationURLIntoIFrame(): void {
+    const urlSource = this.options.startRoute
+      ? new URL(this.options.startRoute, this.bundlerURL).toString()
+      : this.bundlerURL;
+
+    this.iframe.contentWindow?.location.replace(urlSource);
   }
 
   cleanup(): void {
@@ -318,6 +322,16 @@ export class SandpackClient {
   }
 
   public dispatch(message: SandpackMessage): void {
+    /**
+     * Intercept "refresh" dispatch: this will make sure
+     * that the iframe is still in the location it's supposed to be.
+     * External links inside the iframe will change the location and
+     * prevent the user from navigating back.
+     */
+    if (message.type === "refresh") {
+      this.setLocationURLIntoIFrame();
+    }
+
     this.iframeProtocol.dispatch(message);
   }
 

--- a/sandpack-react/src/Issues.stories.tsx
+++ b/sandpack-react/src/Issues.stories.tsx
@@ -13,6 +13,29 @@ export default {
   title: "Bug reports/Issues",
 };
 
+export const Issue561 = (): JSX.Element => {
+  return (
+    <Sandpack
+      files={{
+        "/App.js": `
+import React from 'react';
+
+function App() {
+  return (
+    <a href="https://wikipedia.org">
+      Go to Wikipedia
+    </a>  
+  )
+}
+
+export default App;
+        `,
+      }}
+      template="react"
+    />
+  );
+};
+
 export const Issue482 = (): JSX.Element => {
   const [hidden, setHidden] = useState(false);
 

--- a/sandpack-react/src/Issues.stories.tsx
+++ b/sandpack-react/src/Issues.stories.tsx
@@ -13,29 +13,6 @@ export default {
   title: "Bug reports/Issues",
 };
 
-export const Issue561 = (): JSX.Element => {
-  return (
-    <Sandpack
-      files={{
-        "/App.js": `
-import React from 'react';
-
-function App() {
-  return (
-    <a href="https://wikipedia.org">
-      Go to Wikipedia
-    </a>  
-  )
-}
-
-export default App;
-        `,
-      }}
-      template="react"
-    />
-  );
-};
-
 export const Issue482 = (): JSX.Element => {
   const [hidden, setHidden] = useState(false);
 


### PR DESCRIPTION
Fixed https://github.com/codesandbox/sandpack/issues/561

Sandpack client intercepts the "refresh" dispatch in order to make sure that the iframe is still in the location it's supposed to be. External links inside the iframe will change the location and prevent the user from navigating back.