### PR TITLE
fix(files): normalize paths

### DIFF
--- a/sandpack-client/src/utils.test.ts
+++ b/sandpack-client/src/utils.test.ts
@@ -39,7 +39,7 @@ describe(addPackageJSONIfNeeded, () => {
     );
 
     expect(JSON.parse(output["/package.json"].code).main).toEqual(
-      "old-entry.js"
+      "new-entry.js"
     );
   });
 
@@ -91,7 +91,7 @@ describe(addPackageJSONIfNeeded, () => {
       "new-entry.ts"
     );
 
-    expect(JSON.parse(output["package.json"].code)).toEqual({
+    expect(JSON.parse(output["/package.json"].code)).toEqual({
       main: "new-entry.ts",
       dependencies: { baz: "*", foo: "*" },
       devDependencies: { baz: "*", foo: "*" },

--- a/sandpack-client/src/utils.test.ts
+++ b/sandpack-client/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { addPackageJSONIfNeeded } from "./utils";
+import { addPackageJSONIfNeeded, normalizePath } from "./utils";
 
 const files = {
   "/package.json": {
@@ -95,6 +95,29 @@ describe(addPackageJSONIfNeeded, () => {
       main: "new-entry.ts",
       dependencies: { baz: "*", foo: "*" },
       devDependencies: { baz: "*", foo: "*" },
+    });
+  });
+});
+
+describe(normalizePath, () => {
+  it("adds trailing slash to a string", () => {
+    expect(normalizePath("foo")).toBe("/foo");
+    expect(normalizePath("/foo")).toBe("/foo");
+  });
+
+  it("adds trailing slash to an array of string", () => {
+    expect(normalizePath(["foo", "/baz"])).toStrictEqual(["/foo", "/baz"]);
+    expect(normalizePath(["/foo", "/baz"])).toStrictEqual(["/foo", "/baz"]);
+  });
+
+  it("adds trailing slash to an object", () => {
+    expect(normalizePath({ foo: "", baz: "" })).toStrictEqual({
+      "/baz": "",
+      "/foo": "",
+    });
+    expect(normalizePath({ "/foo": "", "/baz": "" })).toStrictEqual({
+      "/baz": "",
+      "/foo": "",
     });
   });
 });

--- a/sandpack-client/src/utils.ts
+++ b/sandpack-client/src/utils.ts
@@ -34,18 +34,7 @@ export function addPackageJSONIfNeeded(
   devDependencies?: Dependencies,
   entry?: string
 ): SandpackBundlerFiles {
-  const normalizedFilesPath = Object.entries(
-    files
-  ).reduce<SandpackBundlerFiles>(
-    (acc, [key, content]: [string, SandpackBundlerFile]) => {
-      const fileName = key.startsWith("/") ? key : `/${key}`;
-
-      acc[fileName] = content;
-
-      return acc;
-    },
-    {}
-  );
+  const normalizedFilesPath = normalizePath(files);
 
   const packageJsonFile = normalizedFilesPath["/package.json"];
 
@@ -191,3 +180,29 @@ function formatErrorMessage(
   return `${filePath}: ${message}${location}
 ${errorInCode}`;
 }
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export const normalizePath = <R extends any>(path: R): R => {
+  if (typeof path === "string") {
+    return (path.startsWith("/") ? path : `/${path}`) as R;
+  }
+
+  if (Array.isArray(path)) {
+    return path.map((p) => (p.startsWith("/") ? p : `/${p}`)) as R;
+  }
+
+  if (typeof path === "object") {
+    return Object.entries(path as any).reduce<any>(
+      (acc, [key, content]: [string, string | any]) => {
+        const fileName = key.startsWith("/") ? key : `/${key}`;
+
+        acc[fileName] = content;
+
+        return acc;
+      },
+      {}
+    );
+  }
+
+  return undefined as R;
+};

--- a/sandpack-client/src/utils.ts
+++ b/sandpack-client/src/utils.ts
@@ -6,8 +6,6 @@ import type {
   ErrorStackFrame,
 } from "./types";
 
-import type { SandpackBundlerFile } from ".";
-
 const DEPENDENCY_ERROR_MESSAGE = `[sandpack-client]: "dependencies" was not specified - provide either a package.json or a "dependencies" value`;
 const ENTRY_ERROR_MESSAGE = `[sandpack-client]: "entry" was not specified - provide either a package.json with the "main" field or na "entry" value`;
 

--- a/sandpack-react/src/Issues.stories.tsx
+++ b/sandpack-react/src/Issues.stories.tsx
@@ -78,7 +78,11 @@ export const Issue454 = (): JSX.Element => {
 export const FileTab = (): JSX.Element => {
   return (
     <Sandpack
-      options={{ visibleFiles: ["/App.js", "/styles.css"] }}
+      files={{ "foo.sh": "" }}
+      options={{
+        visibleFiles: ["/App.js", "/styles.css"],
+        activeFile: "foo.sh",
+      }}
       template="react"
     />
   );

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -221,7 +221,7 @@ const exhaustedFilesTests = {
   },
   files: {
     "/src/index.tsx": SANDBOX_TEMPLATES["react-ts"].files["/index.tsx"],
-    "/src/App.tsx": `console.log("Hello world");\n\n${SANDBOX_TEMPLATES["react-ts"].files["/App.tsx"].code}`,
+    "src/App.tsx": `console.log("Hello world");\n\n${SANDBOX_TEMPLATES["react-ts"].files["/App.tsx"].code}`,
     "/src/App.test.tsx": `import '@testing-library/jest-dom';
 import React from 'react';
 import { render, screen } from '@testing-library/react';

--- a/sandpack-react/src/contexts/sandpackContext.test.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.test.tsx
@@ -37,7 +37,7 @@ describe(SandpackProvider, () => {
 
       instance.addFile({ "new-file.js": "new-content" });
 
-      expect(instance.state.files["new-file.js"].code).toBe("new-content");
+      expect(instance.state.files["/new-file.js"].code).toBe("new-content");
     });
 
     it("deletes a file", () => {

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -148,7 +148,10 @@ export class SandpackProviderClass extends React.PureComponent<
         return;
       }
 
-      files = { ...files, [pathOrFiles]: { code: code } };
+      files = {
+        ...files,
+        ...convertedFilesToBundlerFiles({ [pathOrFiles]: { code } }),
+      };
     } else if (typeof pathOrFiles === "object") {
       files = { ...files, ...convertedFilesToBundlerFiles(pathOrFiles) };
     }

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -8,6 +8,7 @@ import type {
 import {
   SandpackClient,
   extractErrorDetails,
+  normalizePath,
 } from "@codesandbox/sandpack-client";
 import isEqual from "lodash.isequal";
 import * as React from "react";
@@ -150,13 +151,13 @@ export class SandpackProviderClass extends React.PureComponent<
 
       files = {
         ...files,
-        ...convertedFilesToBundlerFiles({ [pathOrFiles]: { code } }),
+        [pathOrFiles]: { code },
       };
     } else if (typeof pathOrFiles === "object") {
       files = { ...files, ...convertedFilesToBundlerFiles(pathOrFiles) };
     }
 
-    this.setState({ files }, this.updateClients);
+    this.setState({ files: normalizePath(files) }, this.updateClients);
   };
 
   updateClients = (): void => {

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -68,7 +68,11 @@ export class SandpackProviderClass extends React.PureComponent<
     super(props);
 
     const { activeFile, visibleFiles, files, environment } =
-      getSandpackStateFromProps(props);
+      getSandpackStateFromProps({
+        template: props.template,
+        files: props.files,
+        customSetup: props.customSetup,
+      });
 
     this.state = {
       files,
@@ -272,7 +276,11 @@ export class SandpackProviderClass extends React.PureComponent<
      * Custom setup derived from props
      */
     const { activeFile, visibleFiles, files, environment } =
-      getSandpackStateFromProps(this.props);
+      getSandpackStateFromProps({
+        template: this.props.template,
+        files: this.props.files,
+        customSetup: this.props.customSetup,
+      });
 
     /**
      * What the changes on the customSetup props
@@ -600,7 +608,11 @@ export class SandpackProviderClass extends React.PureComponent<
   };
 
   resetFile = (path: string): void => {
-    const { files } = getSandpackStateFromProps(this.props);
+    const { files } = getSandpackStateFromProps({
+      template: this.props.template,
+      files: this.props.files,
+      customSetup: this.props.customSetup,
+    });
 
     this.setState(
       (prevState) => ({
@@ -611,7 +623,11 @@ export class SandpackProviderClass extends React.PureComponent<
   };
 
   resetAllFiles = (): void => {
-    const { files } = getSandpackStateFromProps(this.props);
+    const { files } = getSandpackStateFromProps({
+      template: this.props.template,
+      files: this.props.files,
+      customSetup: this.props.customSetup,
+    });
 
     this.setState({ files }, this.updateClients);
   };

--- a/sandpack-react/src/utils/sandpackUtils.test.ts
+++ b/sandpack-react/src/utils/sandpackUtils.test.ts
@@ -66,6 +66,17 @@ describe(getSandpackStateFromProps, () => {
     expect(setup.files["/App.js"].code).toBe("foo");
   });
 
+  test("files should override template files regardless the leading slash", () => {
+    const setup = getSandpackStateFromProps({
+      template: "react",
+      files: {
+        "App.js": "foo",
+      },
+    });
+
+    expect(setup.files["/App.js"].code).toBe("foo");
+  });
+
   /**
    * activeFile
    */
@@ -92,7 +103,7 @@ describe(getSandpackStateFromProps, () => {
       files: { "foo.js": "" },
       customSetup: { entry: "foo.js" },
     });
-    expect(customSetup.activeFile).toBe("foo.js");
+    expect(customSetup.activeFile).toBe("/foo.js");
   });
 
   test("show activeFile even when it's hidden", () => {
@@ -118,7 +129,7 @@ describe(getSandpackStateFromProps, () => {
       },
     });
 
-    expect(setup.activeFile).toEqual("entry.js");
+    expect(setup.activeFile).toEqual("/entry.js");
   });
 
   /**

--- a/sandpack-react/src/utils/sandpackUtils.test.ts
+++ b/sandpack-react/src/utils/sandpackUtils.test.ts
@@ -21,21 +21,21 @@ describe(resolveFile, () => {
   });
 
   it("resolves the file path without leading slash", () => {
-    const data = resolveFile("file.ts", { "file.js": "" });
+    const data = resolveFile("file.ts", { "/file.js": "" });
 
-    expect(data).toBe("file.js");
+    expect(data).toBe("/file.js");
   });
 
   it("removes the leading slash and resolves the file path", () => {
-    const data = resolveFile("/file.js", { "file.js": "" });
+    const data = resolveFile("file.js", { "/file.js": "" });
 
-    expect(data).toBe("file.js");
+    expect(data).toBe("/file.js");
   });
 
   it("fixes (add/remove) the leading slash and fixes the extension", () => {
-    const data = resolveFile("/file.ts", { "file.js": "" });
+    const data = resolveFile("/file.ts", { "/file.js": "" });
 
-    expect(data).toBe("file.js");
+    expect(data).toBe("/file.js");
   });
 });
 
@@ -51,7 +51,7 @@ describe(getSandpackStateFromProps, () => {
       },
     });
 
-    expect(setup.files["foo.ts"].code).toBe("foo");
+    expect(setup.files["/foo.ts"].code).toBe("foo");
   });
 
   test("files should override template files", () => {
@@ -232,7 +232,7 @@ describe(getSandpackStateFromProps, () => {
     });
 
     const packageContent = JSON.parse(setup.files["/package.json"].code);
-    expect(packageContent.main).toBe("foo.ts");
+    expect(packageContent.main).toBe("/foo.ts");
   });
 
   test("it resolves the entry file, even when the extension is wrong", () => {
@@ -245,7 +245,7 @@ describe(getSandpackStateFromProps, () => {
     });
 
     const packageContent = JSON.parse(setup.files["/package.json"].code);
-    expect(packageContent.main).toBe("entry.js");
+    expect(packageContent.main).toBe("/entry.js");
   });
 
   test("it keeps the entry into package.json main", () => {
@@ -271,7 +271,7 @@ describe(getSandpackStateFromProps, () => {
     });
 
     const packageContent = JSON.parse(setup.files["/package.json"].code);
-    expect(packageContent.main).toEqual("entry.js");
+    expect(packageContent.main).toEqual("/entry.js");
   });
 
   /**

--- a/sandpack-react/src/utils/sandpackUtils.test.ts
+++ b/sandpack-react/src/utils/sandpackUtils.test.ts
@@ -8,28 +8,7 @@ import {
   normalizePath,
 } from "./sandpackUtils";
 
-describe(normalizePath, () => {
-  it("adds trailing slash to a string", () => {
-    expect(normalizePath("foo")).toBe("/foo");
-    expect(normalizePath("/foo")).toBe("/foo");
-  });
 
-  it("adds trailing slash to an array of string", () => {
-    expect(normalizePath(["foo", "/baz"])).toStrictEqual(["/foo", "/baz"]);
-    expect(normalizePath(["/foo", "/baz"])).toStrictEqual(["/foo", "/baz"]);
-  });
-
-  it("adds trailing slash to an object", () => {
-    expect(normalizePath({ foo: "", baz: "" })).toStrictEqual({
-      "/baz": "",
-      "/foo": "",
-    });
-    expect(normalizePath({ "/foo": "", "/baz": "" })).toStrictEqual({
-      "/baz": "",
-      "/foo": "",
-    });
-  });
-});
 
 describe(resolveFile, () => {
   it("resolves the file path based on the extension", () => {

--- a/sandpack-react/src/utils/sandpackUtils.test.ts
+++ b/sandpack-react/src/utils/sandpackUtils.test.ts
@@ -5,7 +5,31 @@ import {
   createSetupFromUserInput,
   resolveFile,
   convertedFilesToBundlerFiles,
+  normalizePath,
 } from "./sandpackUtils";
+
+describe(normalizePath, () => {
+  it("adds trailing slash to a string", () => {
+    expect(normalizePath("foo")).toBe("/foo");
+    expect(normalizePath("/foo")).toBe("/foo");
+  });
+
+  it("adds trailing slash to an array of string", () => {
+    expect(normalizePath(["foo", "/baz"])).toStrictEqual(["/foo", "/baz"]);
+    expect(normalizePath(["/foo", "/baz"])).toStrictEqual(["/foo", "/baz"]);
+  });
+
+  it("adds trailing slash to an object", () => {
+    expect(normalizePath({ foo: "", baz: "" })).toStrictEqual({
+      "/baz": "",
+      "/foo": "",
+    });
+    expect(normalizePath({ "/foo": "", "/baz": "" })).toStrictEqual({
+      "/baz": "",
+      "/foo": "",
+    });
+  });
+});
 
 describe(resolveFile, () => {
   it("resolves the file path based on the extension", () => {

--- a/sandpack-react/src/utils/sandpackUtils.test.ts
+++ b/sandpack-react/src/utils/sandpackUtils.test.ts
@@ -8,8 +8,6 @@ import {
   normalizePath,
 } from "./sandpackUtils";
 
-
-
 describe(resolveFile, () => {
   it("resolves the file path based on the extension", () => {
     const data = resolveFile("/file.js", { "/file.ts": "" });
@@ -199,27 +197,27 @@ describe(getSandpackStateFromProps, () => {
   test("visibleFiles override the files configurations", () => {
     const setup = getSandpackStateFromProps({
       files: {
-        A: { hidden: true, code: "" },
-        B: { hidden: true, code: "" },
+        "A.js": { hidden: true, code: "" },
+        "B.js": { hidden: true, code: "" },
       },
       customSetup: { entry: "A" },
-      options: { visibleFiles: ["A", "B"] },
+      options: { visibleFiles: ["A.js", "B.js"] },
     });
 
-    expect(setup.visibleFiles).toEqual(["A", "B"]);
+    expect(setup.visibleFiles).toEqual(["/A.js", "/B.js"]);
   });
 
   test("activeFile override the files configurations", () => {
     const setup = getSandpackStateFromProps({
       files: {
-        A: { active: true, code: "" },
-        B: { code: "" },
+        "A.js": { active: true, code: "" },
+        "B.js": { code: "" },
       },
       customSetup: { entry: "A" },
       options: { activeFile: "B" },
     });
 
-    expect(setup.activeFile).toEqual("B");
+    expect(setup.activeFile).toEqual("/B.js");
   });
 
   /**

--- a/sandpack-react/src/utils/sandpackUtils.test.ts
+++ b/sandpack-react/src/utils/sandpackUtils.test.ts
@@ -5,7 +5,6 @@ import {
   createSetupFromUserInput,
   resolveFile,
   convertedFilesToBundlerFiles,
-  normalizePath,
 } from "./sandpackUtils";
 
 describe(resolveFile, () => {
@@ -37,6 +36,12 @@ describe(resolveFile, () => {
     const data = resolveFile("/file.ts", { "/file.js": "" });
 
     expect(data).toBe("/file.js");
+  });
+
+  it("resolves a file regardless the file extension", () => {
+    const data = resolveFile("file.sh", { "/file.sh": "" });
+
+    expect(data).toBe("/file.sh");
   });
 });
 

--- a/sandpack-react/src/utils/sandpackUtils.test.ts
+++ b/sandpack-react/src/utils/sandpackUtils.test.ts
@@ -2,7 +2,6 @@ import { REACT_TEMPLATE } from "../templates/react";
 
 import {
   getSandpackStateFromProps,
-  createSetupFromUserInput,
   resolveFile,
   convertedFilesToBundlerFiles,
 } from "./sandpackUtils";
@@ -416,26 +415,6 @@ describe(getSandpackStateFromProps, () => {
         `[sandpack-react]: invalid template "WHATEVER" provided`
       );
     }
-  });
-});
-
-describe(createSetupFromUserInput, () => {
-  test("convert `files` to a key/value format", () => {
-    const setup = createSetupFromUserInput({ files: { "App.js": "" } });
-
-    expect(setup).toStrictEqual({ files: { "App.js": { code: "" } } });
-  });
-
-  test("supports custom properties", () => {
-    const setup = createSetupFromUserInput({
-      files: { "App.js": "" },
-      customSetup: { environment: "create-react-app" },
-    });
-
-    expect(setup).toStrictEqual({
-      environment: "create-react-app",
-      files: { "App.js": { code: "" } },
-    });
   });
 });
 

--- a/sandpack-react/src/utils/sandpackUtils.ts
+++ b/sandpack-react/src/utils/sandpackUtils.ts
@@ -2,9 +2,11 @@ import type {
   SandpackBundlerFile,
   SandpackBundlerFiles,
 } from "@codesandbox/sandpack-client";
-import { addPackageJSONIfNeeded } from "@codesandbox/sandpack-client";
+import {
+  addPackageJSONIfNeeded,
+  normalizePath,
+} from "@codesandbox/sandpack-client";
 
-import type { SandpackFile } from "..";
 import { SANDBOX_TEMPLATES } from "../templates";
 import type {
   SandboxTemplate,
@@ -21,31 +23,6 @@ export interface SandpackContextInfo {
   files: Record<string, SandpackBundlerFile>;
   environment: SandboxEnvironment;
 }
-
-export const normalizePath = <R>(path: R): R => {
-  if (typeof path === "string") {
-    return path.startsWith("/") ? path : `/${path}`;
-  }
-
-  if (Array.isArray(path)) {
-    return path.map((p) => (p.startsWith("/") ? p : `/${p}`));
-  }
-
-  if (typeof path === "object") {
-    return Object.entries(path).reduce<SandpackFiles>(
-      (acc, [key, content]: [string, string | SandpackFile]) => {
-        const fileName = key.startsWith("/") ? key : `/${key}`;
-
-        acc[fileName] = content;
-
-        return acc;
-      },
-      {}
-    );
-  }
-
-  return undefined;
-};
 
 export const getSandpackStateFromProps = (
   props: SandpackProviderProps

--- a/sandpack-react/src/utils/sandpackUtils.ts
+++ b/sandpack-react/src/utils/sandpackUtils.ts
@@ -43,11 +43,9 @@ export const getSandpackStateFromProps = (
     : undefined;
 
   if (visibleFiles.length === 0 && props?.files) {
-    const inputFiles = props.files;
-
     // extract open and active files from the custom input files
-    Object.keys(inputFiles).forEach((filePath) => {
-      const file = inputFiles[filePath];
+    Object.keys(normalizedFilesPath).forEach((filePath) => {
+      const file = normalizedFilesPath[filePath];
       if (typeof file === "string") {
         visibleFiles.push(filePath);
         return;

--- a/sandpack-react/src/utils/sandpackUtils.ts
+++ b/sandpack-react/src/utils/sandpackUtils.ts
@@ -115,6 +115,10 @@ export const resolveFile = (
   files: Record<string, any>
 ): string | undefined => {
   const normalizedFilesPath = normalizePath(files);
+  const normalizedPath = normalizePath(path);
+
+  if (normalizedPath in normalizedFilesPath) return normalizedPath;
+
   if (!path) return undefined;
 
   let resolvedPath = undefined;
@@ -123,15 +127,7 @@ export const resolveFile = (
   const strategies = [".js", ".jsx", ".ts", ".tsx"];
 
   while (!resolvedPath && index < strategies.length) {
-    const fileName = normalizePath(path);
-
-    if (normalizedFilesPath[fileName]) {
-      resolvedPath = normalizedFilesPath;
-
-      return;
-    }
-
-    const removeExtension = fileName.split(".")[0];
+    const removeExtension = normalizedPath.split(".")[0];
     const attemptPath = `${removeExtension}${strategies[index]}`;
 
     if (normalizedFilesPath[attemptPath] !== undefined) {

--- a/sandpack-react/src/utils/sandpackUtils.ts
+++ b/sandpack-react/src/utils/sandpackUtils.ts
@@ -27,7 +27,7 @@ export interface SandpackContextInfo {
 export const getSandpackStateFromProps = (
   props: SandpackProviderProps
 ): SandpackContextInfo => {
-  const normalizedFilesPath = normalizePath(props.files);
+  const normalizedFilesPath = normalizePath(props.files ?? {});
 
   // Merge predefined template with custom setup
   const projectSetup = getSetup({

--- a/sandpack-react/src/utils/sandpackUtils.ts
+++ b/sandpack-react/src/utils/sandpackUtils.ts
@@ -114,6 +114,7 @@ export const resolveFile = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   files: Record<string, any>
 ): string | undefined => {
+  const normalizedFilesPath = normalizePath(files);
   if (!path) return undefined;
 
   let resolvedPath = undefined;
@@ -123,10 +124,17 @@ export const resolveFile = (
 
   while (!resolvedPath && index < strategies.length) {
     const fileName = normalizePath(path);
+
+    if (normalizedFilesPath[fileName]) {
+      resolvedPath = normalizedFilesPath;
+
+      return;
+    }
+
     const removeExtension = fileName.split(".")[0];
     const attemptPath = `${removeExtension}${strategies[index]}`;
 
-    if (files[attemptPath] !== undefined) {
+    if (normalizedFilesPath[attemptPath] !== undefined) {
       resolvedPath = attemptPath;
     }
 

--- a/sandpack-react/src/utils/sandpackUtils.ts
+++ b/sandpack-react/src/utils/sandpackUtils.ts
@@ -38,7 +38,9 @@ export const getSandpackStateFromProps = (
 
   // visibleFiles and activeFile override the setup flags
   let visibleFiles = normalizePath(props.options?.visibleFiles ?? []);
-  let activeFile = normalizePath(props.options?.activeFile);
+  let activeFile = props.options?.activeFile
+    ? resolveFile(props.options?.activeFile, normalizedFilesPath || {})
+    : undefined;
 
   if (visibleFiles.length === 0 && props?.files) {
     const inputFiles = props.files;
@@ -102,7 +104,8 @@ export const getSandpackStateFromProps = (
 
   return {
     visibleFiles: existOpenPath,
-    activeFile,
+    /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+    activeFile: activeFile!,
     files,
     environment: projectSetup.environment,
   };
@@ -121,7 +124,7 @@ export const resolveFile = (
   const strategies = [".js", ".jsx", ".ts", ".tsx"];
 
   while (!resolvedPath && index < strategies.length) {
-    const fileName = path.startsWith("/") ? path : `/${path}`;
+    const fileName = normalizePath(path);
     const removeExtension = fileName.split(".")[0];
     const attemptPath = `${removeExtension}${strategies[index]}`;
 
@@ -193,7 +196,7 @@ export const getSetup = ({
       ...baseTemplate.devDependencies,
       ...setup.devDependencies,
     },
-    entry: setup.entry || baseTemplate.entry,
+    entry: normalizePath(setup.entry || baseTemplate.entry),
     main: setup.main || baseTemplate.main,
     environment: setup.environment || baseTemplate.environment,
   } as SandboxTemplate;

--- a/sandpack-react/src/utils/sandpackUtils.ts
+++ b/sandpack-react/src/utils/sandpackUtils.ts
@@ -27,7 +27,7 @@ export interface SandpackContextInfo {
 export const getSandpackStateFromProps = (
   props: SandpackProviderProps
 ): SandpackContextInfo => {
-  const normalizedFilesPath = normalizePath(props.files ?? {});
+  const normalizedFilesPath = normalizePath(props.files);
 
   // Merge predefined template with custom setup
   const projectSetup = getSetup({
@@ -42,7 +42,7 @@ export const getSandpackStateFromProps = (
     ? resolveFile(props.options?.activeFile, normalizedFilesPath || {})
     : undefined;
 
-  if (visibleFiles.length === 0 && props?.files) {
+  if (visibleFiles.length === 0 && normalizedFilesPath) {
     // extract open and active files from the custom input files
     Object.keys(normalizedFilesPath).forEach((filePath) => {
       const file = normalizedFilesPath[filePath];


### PR DESCRIPTION
Closes #353

Normalizes leading slash on paths looks necessary to make the file tree state and the ability to overwrite template files more reliable. I've noted many cases where a mistyping might lead to the wrong sandbox configuration, especially when this file is a `package.json`. 

Features:
- Introduces `normalizePath` function to ensure leading slash on paths;

Fixes:
- Normalizes path on adding new files to the Sandpack context;
- Make sure custom entry overwrite `main` value on `package.json` file;
- Normalizes `activeFile` and `visibleFiles`: it used to return values that didn't match with the file tree;
- `activeFile` and `visibleFiles` have been ignored when the content was an empty string;