### PR TITLE
fix: style prop no longer passed to React.Fragment

### DIFF
--- a/sandpack-react/src/presets/Sandpack.tsx
+++ b/sandpack-react/src/presets/Sandpack.tsx
@@ -82,6 +82,7 @@ export const Sandpack: SandpackInternal = (props) => {
 
   const hasRightColumn =
     props.options?.showConsole || props.options?.showConsoleButton;
+  const RightColumn = hasRightColumn ? SandpackStack : React.Fragment;
 
   const rightColumnStyle = {
     flexGrow: previewPart,
@@ -92,12 +93,10 @@ export const Sandpack: SandpackInternal = (props) => {
     height: props.options?.editorHeight, // use the original editor height
   };
 
-  const RightColumn: React.FC<{ children: React.ReactNode }> = ({ children }) =>
-    hasRightColumn ? (
-      <SandpackStack style={rightColumnStyle}>{children}</SandpackStack>
-    ) : (
-      <React.Fragment>{children}</React.Fragment>
-    );
+  const rightColumnProps = React.useMemo(
+    () => (hasRightColumn ? { style: rightColumnStyle } : {}),
+    [hasRightColumn]
+  );
 
   /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
   const templateFiles = SANDBOX_TEMPLATES[props.template!] ?? {};
@@ -134,7 +133,7 @@ export const Sandpack: SandpackInternal = (props) => {
         />
 
         {/* @ts-ignore */}
-        <RightColumn>
+        <RightColumn {...rightColumnProps}>
           {mode === "preview" && (
             <SandpackPreview
               actionsChildren={actionsChildren}

--- a/sandpack-react/src/presets/Sandpack.tsx
+++ b/sandpack-react/src/presets/Sandpack.tsx
@@ -82,7 +82,6 @@ export const Sandpack: SandpackInternal = (props) => {
 
   const hasRightColumn =
     props.options?.showConsole || props.options?.showConsoleButton;
-  const RightColumn = hasRightColumn ? SandpackStack : React.Fragment;
 
   const rightColumnStyle = {
     flexGrow: previewPart,
@@ -92,6 +91,13 @@ export const Sandpack: SandpackInternal = (props) => {
     gap: consoleVisibility ? 1 : 0,
     height: props.options?.editorHeight, // use the original editor height
   };
+
+  const RightColumn: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+    hasRightColumn ? (
+      <SandpackStack style={rightColumnStyle}>{children}</SandpackStack>
+    ) : (
+      <React.Fragment>{children}</React.Fragment>
+    );
 
   /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
   const templateFiles = SANDBOX_TEMPLATES[props.template!] ?? {};
@@ -128,7 +134,7 @@ export const Sandpack: SandpackInternal = (props) => {
         />
 
         {/* @ts-ignore */}
-        <RightColumn style={rightColumnStyle}>
+        <RightColumn>
           {mode === "preview" && (
             <SandpackPreview
               actionsChildren={actionsChildren}


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Bug fix

## What is the current behavior?

Currently getting this error when using Sandpack React:
```
Invalid prop `style` supplied to `React.Fragment`. React.Fragment can only have `key` and `children` props.
```

I traced back the error back to this point in the code.

## What is the new behavior?

Don't apply the `style` prop to `React.Fragment`

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

It seemed fine in CodeSandbox projects, but I have done no more testing. Please check everything works!

