### PR TITLE
feat(theme): Cobalt2 Theme

### DIFF
--- a/sandpack-themes/src/cobalt2.ts
+++ b/sandpack-themes/src/cobalt2.ts
@@ -1,0 +1,36 @@
+import type { SandpackTheme } from "./types";
+
+export const cobalt2: SandpackTheme = {
+  colors: {
+    surface1: "#193549",
+    surface2: "#0d3a58",
+    surface3: "#1f4662",
+    clickable: "#aaaaaa",
+    base: "#d0021b",
+    disabled: "#C5C5C5",
+    hover: "#ffffff",
+    accent: "#ffc600",
+    error: "#a22929",
+    errorSurface: "#0d3a58",
+  },
+  syntax: {
+    plain: "#ffffff",
+    comment: {
+      color: "#0088ff",
+      fontStyle: "italic",
+    },
+    keyword: "#ff9d00",
+    tag: "#9effff",
+    punctuation: "#e1efff",
+    definition: "#ffc600",
+    property: "#ffc600",
+    static: "#ffee80",
+    string: "#a5ff90",
+  },
+  font: {
+    body: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
+    mono: '"Operator Mono", "Fira Mono", "DejaVu Sans Mono", Menlo, Consolas, "Liberation Mono", Monaco, "Lucida Console", monospace',
+    size: "13px",
+    lineHeight: "20px",
+  },
+};

--- a/sandpack-themes/src/cobalt2.ts
+++ b/sandpack-themes/src/cobalt2.ts
@@ -6,7 +6,7 @@ export const cobalt2: SandpackTheme = {
     surface2: "#0d3a58",
     surface3: "#1f4662",
     clickable: "#aaaaaa",
-    base: "#d0021b",
+    base: "#ffffff",
     disabled: "#C5C5C5",
     hover: "#ffffff",
     accent: "#ffc600",

--- a/sandpack-themes/src/index.ts
+++ b/sandpack-themes/src/index.ts
@@ -7,3 +7,4 @@ export { nightOwl } from "./nightOwl";
 export { sandpackDark } from "./sandpackDark";
 export { ecoLight } from "./ecoLight";
 export { freeCodeCampDark } from "./freeCodeCampDark";
+export { cobalt2 } from "./cobalt2";


### PR DESCRIPTION
## What kind of change does this pull request introduce?

I'm having a blast creating Sandpack themes using the theme builder! One of the two themes I've created for today adapts [Wes Bos's Cobalt2 VSCode Theme](https://marketplace.visualstudio.com/items?itemName=wesbos.theme-cobalt2) into Sandpack.

## What is the new behavior?

I ported the Cobalt2 Theme using the Sandpack Theme Builder. Here's a screenshot of the theme in Storybook:

![Screenshot of the Cobalt2 Sandpack Theme](https://user-images.githubusercontent.com/28495550/194108126-4b885cab-0422-40e9-88a3-0ed72517bc86.png)


## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Verified the new theme via Storybook

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation; N/A
- [x] Storybook (if applicable);
- [ ] Tests; N/A
- [ ] Ready to be merged;


<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
