### PR TITLE
feat(theme): Level Up Theme

### DIFF
--- a/sandpack-themes/src/index.ts
+++ b/sandpack-themes/src/index.ts
@@ -7,3 +7,4 @@ export { nightOwl } from "./nightOwl";
 export { sandpackDark } from "./sandpackDark";
 export { ecoLight } from "./ecoLight";
 export { freeCodeCampDark } from "./freeCodeCampDark";
+export { levelUp } from "./levelUp";

--- a/sandpack-themes/src/levelUp.ts
+++ b/sandpack-themes/src/levelUp.ts
@@ -1,0 +1,36 @@
+import type { SandpackTheme } from "./types";
+
+export const levelUp: SandpackTheme = {
+  colors: {
+    surface1: "#191324",
+    surface2: "#191324",
+    surface3: "#524763",
+    clickable: "#aaaaaa",
+    base: "#ffffff",
+    disabled: "#aaaaaa",
+    hover: "#ffffff",
+    accent: "#82d8d8",
+    error: "#e54b4b",
+    errorSurface: "#191324",
+  },
+  syntax: {
+    plain: "#ffffff",
+    comment: {
+      color: "#82d8d8",
+      fontStyle: "italic",
+    },
+    keyword: "#e54b4b",
+    tag: "#ff26be",
+    punctuation: "#9588aa",
+    definition: "#82d8d8",
+    property: "#82d8d8",
+    static: "#82d8d8",
+    string: "#a8fe39",
+  },
+  font: {
+    body: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
+    mono: '"MonoLisa", "Fira Mono", "DejaVu Sans Mono", Menlo, Consolas, "Liberation Mono", Monaco, "Lucida Console", monospace',
+    size: "13px",
+    lineHeight: "20px",
+  },
+};


### PR DESCRIPTION
## What kind of change does this pull request introduce?

I'm having a blast creating Sandpack themes using the theme builder! One of the two themes I've created for today adapts [the Level Up Tutorials VSCode theme](https://marketplace.visualstudio.com/items?itemName=leveluptutorials.theme-levelup) into Sandpack.

## What is the new behavior?

I ported the Level Up Theme using the Sandpack Theme Builder. Here's a screenshot of the theme in Storybook:

![image](https://user-images.githubusercontent.com/28495550/194110097-8635f56c-3c18-4935-9349-010fb46af0ee.png)



## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Verified the new theme via Storybook

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation; N/A
- [x] Storybook (if applicable);
- [ ] Tests; N/A
- [ ] Ready to be merged;


<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
