### PR TITLE
chore(docs): Add `key` to SSR snippets

### DIFF
--- a/website/docs/docs/getting-started/ssr.md
+++ b/website/docs/docs/getting-started/ssr.md
@@ -36,6 +36,7 @@ export default function Document() {
         <style
           dangerouslySetInnerHTML={{ __html: getSandpackCssText() }}
           id="sandpack"
+          key="sandpack-css"
         />
       </Head>
       <body>
@@ -58,6 +59,7 @@ export const onRenderBody = ({ setHeadComponents }) => {
   setHeadComponents([
     <style
       id="sandpack"
+      key="sandpack-css"
       dangerouslySetInnerHTML={{
         __html: getSandpackCssText(),
       }}


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Small bug fix

## What is the current behavior?

Gatsby complains with:

```shell
Warning: Each child in a list should have a unique "key" prop.
```

## What is the new behavior?

Adding a `key` to the style tags ensures that React has a non-null value for `key`.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

Running a Gatsby site locally with that script

## Checklist

- [x] Documentation;
- [ ] Storybook (if applicable);
- [ ] Tests;
- [x] Ready to be merged;
