### PR TITLE
fix(sandpack-context): addFile with no code argument

### DIFF
--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -149,14 +149,17 @@ export class SandpackProviderClass extends React.PureComponent<
   updateFile = (pathOrFiles: string | SandpackFiles, code?: string): void => {
     let files = this.state.files;
 
-    if (typeof pathOrFiles === "string" && code) {
-      if (code === this.state.files[pathOrFiles]?.code) {
+    if (typeof pathOrFiles === "string") {
+      if (
+        this.state.files[pathOrFiles]?.code &&
+        code === this.state.files[pathOrFiles].code
+      ) {
         return;
       }
 
       files = {
         ...files,
-        [pathOrFiles]: { code },
+        [pathOrFiles]: { code: code ?? "" },
       };
     } else if (typeof pathOrFiles === "object") {
       files = { ...files, ...convertedFilesToBundlerFiles(pathOrFiles) };


### PR DESCRIPTION
## What kind of change does this pull request introduce?

<!-- Is it a Bug fix, feature, documentation update... -->
Bug fix

## What is the current behavior?

<!-- You can also link to an open issue here -->

https://github.com/codesandbox/sandpack/issues/651

If "addFile" is called with a falsy 'code' value or not passed at all (since it is an optional prop), the file will not be created.

## What is the new behavior?

If 'code' prop is not passed at all, we no longer check that 'code' is truthy. This mean that the existing check:
```
code === this.state.files[pathOrFiles].code
```
would return true if 'code' argument was not passed at all, since undefined === undefined. We do not want this.
So we have introduced one extra check to ensure that we are comparing an existing file in the first place from 'this.state.files[pathOrFiles].code'.

```
if ( this.state.files[pathOrFiles]?.code && code === this.state.files[pathOrFiles].code )
```
This means that if a file doesn't exist already, we will never short circuit and will create the file, since we are not replacing anything. If the file does exist we will compare code passed as the arg to the current file code.


<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

Using the issues sandbox example.

1. Call addFile with no code prop passed
2. Call addFile with empty string passed


## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ N/A ] Documentation;
- [ N/A ] Storybook (if applicable);
- [ N/A ] Tests;
- [ N/A ] Ready to be merged;


<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
