### PR TITLE
Update the link to the 'classer' repository

### DIFF
--- a/website/docs/docs/getting-started/custom-ui.md
+++ b/website/docs/docs/getting-started/custom-ui.md
@@ -13,7 +13,7 @@ In this next section, you can read about all the different options for customizi
 
 Theming controls the color palette and typography, but you can also append your own custom style to existing sandpack components.
 
-For this, sandpack uses a small package called [`classer`](https://github.com/code-hike/codehike/tree/next/packages/classer). To customize existing components, you need to map your own classes to the internal sandpack classes.
+For this, sandpack uses a small package called [`classer`](https://github.com/code-hike/codehike). To customize existing components, you need to map your own classes to the internal sandpack classes.
 
 :::note
 While inspecting your Sandpack instance, notice that our components have classes prefixed with `sp-`.

--- a/website/docs/docs/getting-started/custom-ui.md
+++ b/website/docs/docs/getting-started/custom-ui.md
@@ -13,7 +13,7 @@ In this next section, you can read about all the different options for customizi
 
 Theming controls the color palette and typography, but you can also append your own custom style to existing sandpack components.
 
-For this, sandpack uses a small package called [`classer`](https://github.com/code-hike/codehike). To customize existing components, you need to map your own classes to the internal sandpack classes.
+For this, sandpack uses a small package called [`classer`](https://github.com/code-hike/codehike/blob/next/packages/mdx/src/classer/index.tsx). To customize existing components, you need to map your own classes to the internal sandpack classes.
 
 :::note
 While inspecting your Sandpack instance, notice that our components have classes prefixed with `sp-`.


### PR DESCRIPTION
## What kind of change does this pull request introduce?

I updated the link to the 'classer' repository on [this documentation page](https://sandpack.codesandbox.io/docs/getting-started/custom-ui) as it was previously bringing you to a 404 page.

## What is the current behavior?

The link currently brings you to a 404 page.

## What is the new behavior?

The link brings you to the GitHub repository for the classer package.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. I visited the link to make sure it works.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [NA] Documentation;
- [NA] Storybook (if applicable);
- [NA] Tests;
- [x] Ready to be merged;


<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
