### PR TITLE
fix(sandpack-react): safeguard against full page crash when there is no visible files

### DIFF
--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -389,11 +389,12 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
     React.useEffect(() => {
       if (cmView.current && code !== internalCode) {
         const view = cmView.current;
-        const selection = view.state.selection.ranges.some(
-          ({ to, from }) => to > code?.length || from > code?.length
-        )
-          ? EditorSelection.cursor(code?.length)
-          : view.state.selection;
+        const selection =
+          view.state.selection.ranges.some(
+            ({ to, from }) => to > code?.length || from > code?.length
+          ) && code !== undefined
+            ? EditorSelection.cursor(code?.length)
+            : view.state.selection;
 
         const changes = {
           from: 0,

--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -389,16 +389,22 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
     React.useEffect(() => {
       if (cmView.current && code !== internalCode) {
         const view = cmView.current;
-
         const selection = view.state.selection.ranges.some(
-          ({ to, from }) => to > code.length || from > code.length
+          ({ to, from }) => to > code?.length || from > code?.length
         )
-          ? EditorSelection.cursor(code.length)
+          ? EditorSelection.cursor(code?.length)
           : view.state.selection;
 
-        const changes = { from: 0, to: view.state.doc.length, insert: code };
+        const changes = {
+          from: 0,
+          to: view.state.doc?.length,
+          insert: code ?? "",
+        };
 
-        view.dispatch({ changes, selection });
+        view.dispatch({
+          changes,
+          selection,
+        });
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [code]);

--- a/sandpack-react/src/components/CodeEditor/index.tsx
+++ b/sandpack-react/src/components/CodeEditor/index.tsx
@@ -102,7 +102,7 @@ export const SandpackCodeEditor = React.forwardRef<
     const { sandpack } = useSandpack();
     const { code, updateCode, readOnly: readOnlyFile } = useActiveCode();
     const { activeFile, status, editorState } = sandpack;
-    const shouldShowTabs = showTabs ?? sandpack.visibleFiles.length > 1;
+    const shouldShowTabs = showTabs ?? sandpack.visibleFiles?.length > 1;
 
     const c = useClasser(THEME_PREFIX);
 

--- a/sandpack-react/src/components/CodeViewer/index.tsx
+++ b/sandpack-react/src/components/CodeViewer/index.tsx
@@ -58,7 +58,7 @@ export const SandpackCodeViewer = React.forwardRef<
     const { code } = useActiveCode();
     const c = useClasser(THEME_PREFIX);
 
-    const shouldShowTabs = showTabs ?? sandpack.visibleFiles.length > 1;
+    const shouldShowTabs = showTabs ?? sandpack.visibleFiles?.length > 1;
 
     return (
       <SandpackStack {...props}>

--- a/sandpack-react/src/components/FileExplorer/utils.ts
+++ b/sandpack-react/src/components/FileExplorer/utils.ts
@@ -11,7 +11,7 @@ export const fromPropsToModules = ({
   autoHiddenFiles?: boolean;
   visibleFiles: string[];
 }): { directories: string[]; modules: string[] } => {
-  const hasVisibleFilesOption = visibleFiles.length > 0;
+  const hasVisibleFilesOption = visibleFiles?.length > 0;
 
   /**
    * When visibleFiles or activeFile are set, the hidden and active flags on the files prop are ignored.

--- a/sandpack-react/src/components/FileTabs/index.tsx
+++ b/sandpack-react/src/components/FileTabs/index.tsx
@@ -146,7 +146,7 @@ export const FileTabs = ({
             type="button"
           >
             {getTriggerText(filePath)}
-            {closableTabs && visibleFiles.length > 1 && (
+            {closableTabs && visibleFiles?.length > 1 && (
               <span
                 className={classNames(c("close-button"), closeButtonClassName)}
                 onClick={handleCloseFile}

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -78,8 +78,8 @@ export class SandpackProviderClass extends React.PureComponent<
     this.state = {
       files,
       environment,
-      visibleFiles,
-      visibleFilesFromProps: visibleFiles,
+      visibleFiles: visibleFiles ?? [],
+      visibleFilesFromProps: visibleFiles ?? [],
       activeFile,
       startRoute: this.props.options?.startRoute,
       bundlerState: undefined,
@@ -498,7 +498,7 @@ export class SandpackProviderClass extends React.PureComponent<
   };
 
   closeFile = (path: string): void => {
-    if (this.state.visibleFiles.length === 1) {
+    if (this.state.visibleFiles?.length === 1) {
       return;
     }
 

--- a/sandpack-react/src/utils/sandpackUtils.ts
+++ b/sandpack-react/src/utils/sandpackUtils.ts
@@ -48,7 +48,7 @@ export const getSandpackStateFromProps = (
     ? resolveFile(props.options?.activeFile, normalizedFilesPath || {})
     : undefined;
 
-  if (visibleFiles.length === 0 && normalizedFilesPath) {
+  if (visibleFiles?.length === 0 && normalizedFilesPath) {
     // extract open and active files from the custom input files
     Object.keys(normalizedFilesPath).forEach((filePath) => {
       const file = normalizedFilesPath[filePath];
@@ -70,7 +70,7 @@ export const getSandpackStateFromProps = (
     });
   }
 
-  if (visibleFiles.length === 0) {
+  if (visibleFiles?.length === 0) {
     // If no files are received, use the project setup / template
     visibleFiles = [projectSetup.main];
   }


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Bux fix? 

TLDR: Added lots of optional chaining on "visibleFiles" and "code" to prevent errors where code is undefined or there are no visibleFiles.

This change prevents sandpack from erroring out in the scenario where there a no "active files" in view, which results in "code" being undefined among other things.

While this behaviour is not possible unless you start to play around with the 'deleteFile' consumer from context, I do believe  this would be a great "fix" to get in for people to play around further with customizing sandpack.
To clarify, this "bug" is not possible unless you use the sandpack provider and delete the active file with no other files being open.

## What is the current behavior?

<img width="910" alt="image" src="https://user-images.githubusercontent.com/17838632/207007118-3b74903b-5274-4672-ad8a-32b2eb0c6697.png">


<!-- You can also link to an open issue here -->

Currently if you delete the last remaining active file, the whole page crashes.


## What is the new behavior?

New behaviour, the page doesn't crash and you receive a relevant error inside of the sandbox. This seems correct. Seen below (Deleted app.ts from the react.ts template). 
<img width="580" alt="image" src="https://user-images.githubusercontent.com/17838632/207006271-3d468b89-06c3-4b76-97bf-cc7b57153961.png">

With the following console errors:
<img width="559" alt="image" src="https://user-images.githubusercontent.com/17838632/207006566-985072c9-5f4c-4db6-a46d-bd7fd2d1fa10.png">



## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Create a local sandpack
2. Use the deleteFile from context on the only active file
3. Boom

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ N/A ] Documentation;
- [ N/A ] Storybook (if applicable);
- [ N/A ] Tests;
- [X] Ready to be merged;


