### PR TITLE
fix(sandpack-react): prevent crash upon deleting last visible file

### DIFF
--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -110,7 +110,7 @@ export interface CodeMirrorRef {
 export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
   (
     {
-      code,
+      code = "",
       filePath,
       fileType,
       onCodeUpdate,

--- a/sandpack-react/src/contexts/sandpackContext.test.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.test.tsx
@@ -54,6 +54,38 @@ describe(SandpackProvider, () => {
       ]);
     });
 
+    it("deletes the activeFile and set the following visibleFile as active", () => {
+      const root = create(
+        <SandpackProvider
+          template="react"
+          options={{ activeFile: "/App.js", visibleFiles: ["/styles.css"] }}
+        />
+      );
+
+      const instance = root.getInstance();
+
+      instance.runSandpack();
+      instance.deleteFile("/App.js");
+
+      expect(instance.state.activeFile).toBe("/styles.css");
+    });
+
+    it("deletes the activeFile and set the entry file if there no visibleFile left", () => {
+      const root = create(
+        <SandpackProvider
+          template="react"
+          options={{ activeFile: "/App.js", visibleFiles: [] }}
+        />
+      );
+
+      const instance = root.getInstance();
+
+      instance.runSandpack();
+      instance.deleteFile("/App.js");
+
+      expect(instance.state.activeFile).toBe("/index.js");
+    });
+
     it("updates a file", () => {
       const instance = createContext();
 
@@ -105,7 +137,7 @@ describe(SandpackProvider, () => {
       expect(instance.state.editorState).toBe("dirty");
     });
 
-    it("should return a pristine value after reseting files", () => {
+    it("should return a pristine value after reset files", () => {
       const instance = createContext();
 
       expect(instance.state.editorState).toBe("pristine");

--- a/sandpack-react/src/contexts/sandpackContext.test.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.test.tsx
@@ -83,7 +83,7 @@ describe(SandpackProvider, () => {
       instance.runSandpack();
       instance.deleteFile("/App.js");
 
-      expect(instance.state.activeFile).toBe("/index.js");
+      expect(instance.state.activeFile).toBe("/package.json");
     });
 
     it("updates a file", () => {

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -23,7 +23,6 @@ import type {
 } from "../types";
 import {
   convertedFilesToBundlerFiles,
-  getEntryFile,
   getSandpackStateFromProps,
 } from "../utils/sandpackUtils";
 import { generateRandomId } from "../utils/stringUtils";
@@ -523,17 +522,18 @@ export class SandpackProviderClass extends React.PureComponent<
     this.setState(({ visibleFiles, files, activeFile }) => {
       const newFiles = { ...files };
       delete newFiles[path];
-      
+
       const remainingVisibleFiles = visibleFiles.filter(
         (openPath) => openPath !== path
       );
       const deletedLastVisibleFile = remainingVisibleFiles.length === 0;
-      const entryFile: string = getEntryFile(files);
 
       if (deletedLastVisibleFile) {
+        const nextFile = Object.keys(files)[Object.keys(files).length - 1];
+
         return {
-          visibleFiles: [entryFile],
-          activeFile: entryFile,
+          visibleFiles: [nextFile],
+          activeFile: nextFile,
           files: newFiles,
         };
       }

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -23,6 +23,7 @@ import type {
 } from "../types";
 import {
   convertedFilesToBundlerFiles,
+  getEntryFile,
   getSandpackStateFromProps,
 } from "../utils/sandpackUtils";
 import { generateRandomId } from "../utils/stringUtils";
@@ -519,12 +520,29 @@ export class SandpackProviderClass extends React.PureComponent<
   };
 
   deleteFile = (path: string): void => {
-    this.setState(({ visibleFiles, files }) => {
+    this.setState(({ visibleFiles, files, activeFile }) => {
       const newFiles = { ...files };
       delete newFiles[path];
+      const remainingVisibleFiles = visibleFiles.filter(
+        (openPath) => openPath !== path
+      );
+      const deletedLastVisibleFile = remainingVisibleFiles.length === 0;
+      const entryFile: string = getEntryFile(files);
+
+      if (deletedLastVisibleFile) {
+        return {
+          visibleFiles: [entryFile],
+          activeFile: entryFile,
+          files: newFiles,
+        };
+      }
 
       return {
-        visibleFiles: visibleFiles.filter((openPath) => openPath !== path),
+        visibleFiles: remainingVisibleFiles,
+        activeFile:
+          path === activeFile
+            ? remainingVisibleFiles[remainingVisibleFiles.length - 1]
+            : activeFile,
         files: newFiles,
       };
     }, this.updateClients);

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -523,6 +523,7 @@ export class SandpackProviderClass extends React.PureComponent<
     this.setState(({ visibleFiles, files, activeFile }) => {
       const newFiles = { ...files };
       delete newFiles[path];
+      
       const remainingVisibleFiles = visibleFiles.filter(
         (openPath) => openPath !== path
       );

--- a/sandpack-react/src/utils/sandpackUtils.ts
+++ b/sandpack-react/src/utils/sandpackUtils.ts
@@ -250,16 +250,3 @@ export const convertedFilesToBundlerFiles = (
     return acc;
   }, {});
 };
-
-export const getEntryFile = (files: SandpackBundlerFiles) => {
-  let entryFile = "";
-  try {
-    entryFile = JSON.parse(files["/package.json"]?.code)?.main;
-  } catch {
-    const entryRegex = /\"main\"\s*:\s*\"([^"]+)\"/;
-    const match = entryRegex.exec(files["/package.json"]?.code);
-    const mainValue = match?.[1] ?? "";
-    entryFile = mainValue;
-  }
-  return entryFile;
-};

--- a/sandpack-react/src/utils/sandpackUtils.ts
+++ b/sandpack-react/src/utils/sandpackUtils.ts
@@ -250,3 +250,16 @@ export const convertedFilesToBundlerFiles = (
     return acc;
   }, {});
 };
+
+export const getEntryFile = (files: SandpackBundlerFiles) => {
+  let entryFile = "";
+  try {
+    entryFile = JSON.parse(files["/package.json"]?.code)?.main;
+  } catch {
+    const entryRegex = /\"main\"\s*:\s*\"([^"]+)\"/;
+    const match = entryRegex.exec(files["/package.json"]?.code);
+    const mainValue = match?.[1] ?? "";
+    entryFile = mainValue;
+  }
+  return entryFile;
+};


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Alternative to https://github.com/codesandbox/sandpack/pull/659

TLDR: When deleteFile is called, if there are no visibleFiles then open the entryFile. Also set the activeFile is the currently activeFile is deleted.

This change prevents sandpack from erroring out in the scenario where there a no "active files" in view, which results in "code" being undefined among other things.

## What is the current behavior?

<img width="910" alt="image" src="https://user-images.githubusercontent.com/17838632/207007118-3b74903b-5274-4672-ad8a-32b2eb0c6697.png">


<!-- You can also link to an open issue here -->

Currently if you delete the last remaining active file, the whole page crashes.


## What is the new behavior?

New behaviour, the page doesn't crash and you receive a relevant error inside of the sandbox. This seems correct. Seen below (Deleted app.ts from the react.ts template). 
This automatically opens the entry file and presents an error related to user code.

<img width="921" alt="image" src="https://user-images.githubusercontent.com/17838632/207039586-d88e345a-67ef-486d-a078-4d68caaa8126.png">




## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Create a local sandpack
2. Use the deleteFile from context on the active file
3. Boom

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ N/A ] Documentation;
- [ N/A ] Storybook (if applicable);
- [ N/A ] Tests;
- [X] Ready to be merged;


