### PR TITLE
fix: activefile issue

### DIFF
--- a/sandpack-react/src/Issues.stories.tsx
+++ b/sandpack-react/src/Issues.stories.tsx
@@ -85,6 +85,16 @@ export const Issue454 = (): JSX.Element => {
   );
 };
 
+export const Issue663 = (): JSX.Element => (
+  <Sandpack
+    options={{
+      showTabs: true,
+      activeFile: "/index.tsx",
+    }}
+    template="react-ts"
+  />
+);
+
 export const FileTab = (): JSX.Element => {
   return (
     <Sandpack

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -241,6 +241,7 @@ export type SandpackPredefinedTemplate =
   | "vanilla-ts"
   | "vue"
   | "vue3"
+  | "vue3-ts"
   | "svelte"
   | "solid";
 

--- a/sandpack-react/src/utils/sandpackUtils.ts
+++ b/sandpack-react/src/utils/sandpackUtils.ts
@@ -15,6 +15,7 @@ import type {
   SandpackSetup,
   SandpackFiles,
   SandboxEnvironment,
+  SandpackFile,
 } from "../types";
 
 export interface SandpackContextInfo {
@@ -23,6 +24,13 @@ export interface SandpackContextInfo {
   files: Record<string, SandpackBundlerFile>;
   environment: SandboxEnvironment;
 }
+
+const getActiveFileFromFiles = (files: SandpackFiles): string => {
+  const item = Object.entries(files || {}).find(
+    (v) => !!(v[1] as SandpackFile).active
+  );
+  return item ? item[0] : "";
+};
 
 /**
  * Creates a standard sandpack state given the setup,
@@ -43,10 +51,20 @@ export const getSandpackStateFromProps = (
   });
 
   // visibleFiles and activeFile override the setup flags
+  const activeFileFromProps = props.options?.activeFile;
+  const activeFileFromFiles = getActiveFileFromFiles(
+    normalizedFilesPath as SandpackFiles
+  );
   let visibleFiles = normalizePath(props.options?.visibleFiles ?? []);
-  let activeFile = props.options?.activeFile
-    ? resolveFile(props.options?.activeFile, normalizedFilesPath || {})
+  let activeFile = activeFileFromProps
+    ? normalizedFilesPath
+      ? resolveFile(activeFileFromProps, normalizedFilesPath || {})
+      : activeFileFromProps
     : undefined;
+
+  if (!activeFile && activeFileFromFiles) {
+    activeFile = activeFileFromFiles;
+  }
 
   if (visibleFiles.length === 0 && normalizedFilesPath) {
     // extract open and active files from the custom input files


### PR DESCRIPTION
# Bug report

## Packages affected

-   [ ] sandpack-client
-   [x] sandpack-react

## Description of the problem

The issues start from [issue 595](https://github.com/codesandbox/sandpack/pull/595) commit.

- The `activeFile` prop in `options` does not take effect. 
- The `active` option in the `files` prop does not take effect.

```jsx
<Sandpack
  template="react"
  options={{
    showTabs: true,
    visibleFiles: ['/App.js', '/index.js'],
    activeFile: '/index.js',
  }}
/>
```

<img width="460" alt="image" src="https://user-images.githubusercontent.com/12525415/207547229-c36767f8-6136-4616-98a0-db73a04954cd.png">

It should be like this:
<img width="411" alt="image" src="https://user-images.githubusercontent.com/12525415/207547395-29f7d318-815a-4ddc-bbd8-281816934b65.png">
