### PR TITLE
fix(getSandpackStateFromProps): get activeFile from files from props + template files

### DIFF
--- a/sandpack-react/src/Issues.stories.tsx
+++ b/sandpack-react/src/Issues.stories.tsx
@@ -23,6 +23,16 @@ export const FlushServerVsClient = (): JSX.Element => {
   );
 };
 
+export const Issue663 = (): JSX.Element => (
+  <Sandpack
+    options={{
+      showTabs: true,
+      activeFile: "/index.tsx",
+    }}
+    template="react-ts"
+  />
+);
+
 export const Issue482 = (): JSX.Element => {
   const [hidden, setHidden] = useState(false);
 

--- a/sandpack-react/src/utils/sandpackUtils.test.ts
+++ b/sandpack-react/src/utils/sandpackUtils.test.ts
@@ -136,10 +136,20 @@ describe(getSandpackStateFromProps, () => {
     expect(setup.activeFile).toEqual("/entry.js");
   });
 
+  test("custom activeFile", () => {
+    const setup = getSandpackStateFromProps({
+      template: "react",
+      options: {
+        activeFile: "/index.js",
+      },
+    });
+
+    expect(setup.activeFile).toBe("/index.js");
+  });
+
   /**
    * hidden file
    */
-
   test("exclude hidden files from custom files", () => {
     const setup = getSandpackStateFromProps({
       files: {

--- a/sandpack-react/src/utils/sandpackUtils.ts
+++ b/sandpack-react/src/utils/sandpackUtils.ts
@@ -39,7 +39,7 @@ export const getSandpackStateFromProps = (
   const projectSetup = combineTemplateFilesToSetup({
     template: props.template,
     customSetup: props.customSetup,
-    files: normalizePath(props.files),
+    files: normalizedFilesPath,
   });
 
   // visibleFiles and activeFile override the setup flags

--- a/sandpack-react/src/utils/sandpackUtils.ts
+++ b/sandpack-react/src/utils/sandpackUtils.ts
@@ -39,13 +39,13 @@ export const getSandpackStateFromProps = (
   const projectSetup = combineTemplateFilesToSetup({
     template: props.template,
     customSetup: props.customSetup,
-    files: normalizedFilesPath,
+    files: normalizePath(props.files),
   });
 
   // visibleFiles and activeFile override the setup flags
   let visibleFiles = normalizePath(props.options?.visibleFiles ?? []);
   let activeFile = props.options?.activeFile
-    ? resolveFile(props.options?.activeFile, normalizedFilesPath || {})
+    ? resolveFile(props.options?.activeFile, projectSetup.files)
     : undefined;
 
   if (visibleFiles.length === 0 && normalizedFilesPath) {


### PR DESCRIPTION
`activeFile` used to look for the file path from an incomplete file tree (only files from props), when it should look for it from the files from props **and** the files introduced by the default template, which is the output of `combineTemplateFilesToSetup`. Unfortunately, this was a mistake from the last breaking change, but easy to fix. 

Thanks @jerrywu001 for reporting it 🙌 

Closes #664
Closes #663