### PR TITLE
[Not for merge yet] Highlight <foo> differently from <Foo>

### DIFF
--- a/sandpack-react/src/components/CodeEditor/utils.ts
+++ b/sandpack-react/src/components/CodeEditor/utils.ts
@@ -119,7 +119,7 @@ export const getSyntaxHighlight = (theme: SandpackTheme): HighlightStyle =>
       class: classNameToken("static"),
     },
     {
-      tag: tags.tagName,
+      tag: tags.standard(tags.tagName),
       class: classNameToken("tag"),
     },
     { tag: tags.variableName, class: classNameToken("plain") },
@@ -130,7 +130,7 @@ export const getSyntaxHighlight = (theme: SandpackTheme): HighlightStyle =>
     },
     {
       // Highlight function definition differently (eg: functional component def in React)
-      tag: tags.definition(tags.function(tags.variableName)),
+      tag: [tags.definition(tags.function(tags.variableName)), tags.tagName],
       class: classNameToken("definition"),
     },
     {


### PR DESCRIPTION
This is a port of changes in https://github.com/lezer-parser/javascript/commit/00173306dc20e2b1f364cc30b6de0398156e8f42.

See https://github.com/codemirror/dev/issues/956 for context.

I don't think merging this would actually work unless you backport the changes from https://github.com/codemirror/dev/issues/956 to the old version of `@codemirror/highlight` and `@lezer/lang-javascript`. Which I did in my local copy but maybe that's too much. I really want this change though.

---

A proper way would be to of course actually upgrade. And then do this PR.