### PR TITLE
fix(highlight inline error): make sure it highlight the correct file

### DIFF
--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -414,6 +414,7 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
           } else if (
             message.type === "action" &&
             message.action === "show-error" &&
+            message.path === filePath &&
             message.line
           ) {
             view?.dispatch({


### PR DESCRIPTION
The show highlight inline error feature didn't use to consider multiple files, which led to an unexpected state where it highlighted the wrong module/file instead of only the one which triggered the error. Example:
 
![image](https://user-images.githubusercontent.com/4838076/208405057-7fa23e09-ecfe-4e82-9203-be6f75990491.png)

Fortunately, the bundler provider the path of the file, and we can filter errors out on each show-error messages.

---

cc @gaearon 
