### PR TITLE
feat(Sandpack-preset): split panel

### DIFF
--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -25,6 +25,14 @@ export const Preset = (): JSX.Element => {
     <>
       <div style={{ maxWidth: 820, margin: "auto", padding: "4em 0" }}>
         <Sandpack
+          files={{
+            "App.js": `
+export default function App() {
+  return <h1 onClick={() => console.log("Hello world")}>Hello World</h1>
+}
+
+          `,
+          }}
           options={{
             showLineNumbers: true,
             showConsole: true,

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -20,6 +20,14 @@ export default {
   title: "Intro/Playground",
 };
 
+export const Preset = (): JSX.Element => {
+  return (
+    <div style={{ width: 820, margin: "auto", padding: "4em 0" }}>
+      <Sandpack options={{ showLineNumbers: true }} template="react" />
+    </div>
+  );
+};
+
 export const Main = (): JSX.Element => {
   const [config, setConfig] = useState({
     Components: {

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -22,9 +22,29 @@ export default {
 
 export const Preset = (): JSX.Element => {
   return (
-    <div style={{ width: 820, margin: "auto", padding: "4em 0" }}>
-      <Sandpack options={{ showLineNumbers: true }} template="react" />
-    </div>
+    <>
+      <div style={{ width: 820, margin: "auto", padding: "4em 0" }}>
+        <Sandpack
+          options={{
+            showLineNumbers: true,
+            showConsole: true,
+            showConsoleButton: true,
+          }}
+          template="react"
+        />
+      </div>
+
+      <div style={{ width: 300, margin: "auto", padding: "4em 0" }}>
+        <Sandpack
+          options={{
+            showLineNumbers: true,
+            showConsole: true,
+            showConsoleButton: true,
+          }}
+          template="react"
+        />
+      </div>
+    </>
   );
 };
 

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -46,16 +46,16 @@ export default function App() {
         <Sandpack template="react" />
       </div>
 
-      <div style={{ width: 300, margin: "auto", padding: "4em 0" }}>
-        <Sandpack
-          options={{
-            showLineNumbers: true,
-            showConsole: true,
-            showConsoleButton: true,
-          }}
-          template="react"
-        />
-      </div>
+      {/* <div style={{ width: 300, margin: "auto", padding: "4em 0" }}> */}
+      <Sandpack
+        options={{
+          showLineNumbers: true,
+          showConsole: true,
+          showConsoleButton: true,
+        }}
+        template="react"
+      />
+      {/* </div> */}
     </>
   );
 };

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -38,6 +38,7 @@ export const Preset = (): JSX.Element => {
             showLineNumbers: true,
             showConsole: true,
             showConsoleButton: true,
+            resizablePanels: false,
           }}
           template="react"
         />

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -32,6 +32,10 @@ export const Preset = (): JSX.Element => {
           }}
           template="react"
         />
+
+        <br />
+
+        <Sandpack template="react" />
       </div>
 
       <div style={{ width: 300, margin: "auto", padding: "4em 0" }}>

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -23,7 +23,7 @@ export default {
 export const Preset = (): JSX.Element => {
   return (
     <>
-      <div style={{ width: 820, margin: "auto", padding: "4em 0" }}>
+      <div style={{ maxWidth: 820, margin: "auto", padding: "4em 0" }}>
         <Sandpack
           options={{
             showLineNumbers: true,

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -26,9 +26,10 @@ export const Preset = (): JSX.Element => {
       <div style={{ maxWidth: 820, margin: "auto", padding: "4em 0" }}>
         <Sandpack
           files={{
-            "App.js": `
-export default function App() {
-  return <h1 onClick={() => console.log("Hello world")}>Hello World</h1>
+            "App.js": `export default function App() {
+  return <h1 onClick={() => {
+    console.log("Hello world");
+  }}>Hello World</h1>
 }
 
           `,
@@ -43,19 +44,25 @@ export default function App() {
 
         <br />
 
-        <Sandpack template="react" />
-      </div>
+        <Sandpack
+          options={{
+            showLineNumbers: true,
+            showConsole: false,
+            showConsoleButton: false,
+          }}
+          template="vue"
+        />
 
-      {/* <div style={{ width: 300, margin: "auto", padding: "4em 0" }}> */}
-      <Sandpack
-        options={{
-          showLineNumbers: true,
-          showConsole: true,
-          showConsoleButton: true,
-        }}
-        template="react"
-      />
-      {/* </div> */}
+        <br />
+
+        <Sandpack
+          options={{
+            showLineNumbers: true,
+            showConsole: false,
+            showConsoleButton: true,
+          }}
+        />
+      </div>
     </>
   );
 };

--- a/sandpack-react/src/components/Preview/index.tsx
+++ b/sandpack-react/src/components/Preview/index.tsx
@@ -160,6 +160,7 @@ export const SandpackPreview = React.forwardRef<
               // set height based on the content only in auto mode
               // and when the computed height was returned by the bundler
               height: iframeComputedHeight ? iframeComputedHeight : undefined,
+              pointerEvents: "none",
             }}
             title="Sandpack Preview"
           />

--- a/sandpack-react/src/components/Preview/index.tsx
+++ b/sandpack-react/src/components/Preview/index.tsx
@@ -160,7 +160,6 @@ export const SandpackPreview = React.forwardRef<
               // set height based on the content only in auto mode
               // and when the computed height was returned by the bundler
               height: iframeComputedHeight ? iframeComputedHeight : undefined,
-              pointerEvents: "none",
             }}
             title="Sandpack Preview"
           />

--- a/sandpack-react/src/components/common/Layout.tsx
+++ b/sandpack-react/src/components/common/Layout.tsx
@@ -33,7 +33,6 @@ export const layoutClassName = css({
     flexGrow: 1,
     flexShrink: 1,
     flexBasis: "0",
-    minWidth: "350px",
     height: "$layout$height",
 
     "@media print": {

--- a/sandpack-react/src/components/common/Layout.tsx
+++ b/sandpack-react/src/components/common/Layout.tsx
@@ -41,10 +41,13 @@ export const layoutClassName = css({
     },
 
     "@media screen and (max-width: 768px)": {
-      height: "auto",
+      [`&:not(.${THEME_PREFIX}-preview, .${THEME_PREFIX}-editor, .${THEME_PREFIX}-preset-column)`]:
+        {
+          height: "calc($layout$height / 2)",
+        },
 
       /* triggers the layout break at the 768px breakpoint, not when the component is less then 700px */
-      minWidth: "100% !important;",
+      minWidth: "100%",
     },
   },
 

--- a/sandpack-react/src/components/common/Stack.tsx
+++ b/sandpack-react/src/components/common/Stack.tsx
@@ -13,7 +13,6 @@ export const stackClassName = css({
   width: "100%",
   position: "relative",
   backgroundColor: "$colors$surface1",
-  // transition: "flex $transitions$default",
   gap: 1, // border between components
 
   [`&:has(.${THEME_PREFIX}-stack)`]: {

--- a/sandpack-react/src/components/common/Stack.tsx
+++ b/sandpack-react/src/components/common/Stack.tsx
@@ -13,7 +13,7 @@ export const stackClassName = css({
   width: "100%",
   position: "relative",
   backgroundColor: "$colors$surface1",
-  transition: "flex $transitions$default",
+  // transition: "flex $transitions$default",
   gap: 1, // border between components
 
   [`&:has(.${THEME_PREFIX}-stack)`]: {

--- a/sandpack-react/src/presets/Sandpack.tsx
+++ b/sandpack-react/src/presets/Sandpack.tsx
@@ -38,7 +38,7 @@ export const Sandpack: SandpackInternal = ({
 }) => {
   // fallback values
   options ??= {};
-  options.resizablePanel ??= true;
+  options.resizablePanels ??= true;
   options.editorWidthPercentage ??= 50;
   options.showConsole ??= false;
 

--- a/sandpack-react/src/presets/Sandpack.tsx
+++ b/sandpack-react/src/presets/Sandpack.tsx
@@ -167,6 +167,7 @@ export const Sandpack: SandpackInternal = ({
   };
 
   React.useEffect(() => {
+    if (!options?.resizablePanels) return;
     document.body.addEventListener("mousemove", onDragMove);
     document.body.addEventListener("mouseup", stopDragging);
 
@@ -174,7 +175,7 @@ export const Sandpack: SandpackInternal = ({
       document.body.removeEventListener("mousemove", onDragMove);
       document.body.removeEventListener("mouseup", stopDragging);
     };
-  }, []);
+  }, [options]);
 
   React.useEffect(() => {
     setConsoleVisibility(options?.showConsole ?? false);
@@ -201,17 +202,19 @@ export const Sandpack: SandpackInternal = ({
           }}
         />
 
-        <div
-          className={classNames(
-            dragHandler({ direction: "horizontal" }),
-            THEME_PREFIX + "-resize-handler"
-          )}
-          data-direction="horizontal"
-          onMouseDown={(event): void => {
-            dragEventTargetRef.current = event.target;
-          }}
-          style={{ left: `calc(${horizontalSize}% - 5px)` }}
-        />
+        {options.resizablePanels && (
+          <div
+            className={classNames(
+              dragHandler({ direction: "horizontal" }),
+              THEME_PREFIX + "-resize-handler"
+            )}
+            data-direction="horizontal"
+            onMouseDown={(event): void => {
+              dragEventTargetRef.current = event.target;
+            }}
+            style={{ left: `calc(${horizontalSize}% - 5px)` }}
+          />
+        )}
 
         {/* @ts-ignore */}
         <RightColumn
@@ -236,7 +239,7 @@ export const Sandpack: SandpackInternal = ({
 
           {(options.showConsoleButton || consoleVisibility) && (
             <>
-              {consoleVisibility && (
+              {options.resizablePanels && consoleVisibility && (
                 <div
                   className={classNames(
                     dragHandler({ direction: "vertical" }),

--- a/sandpack-react/src/presets/Sandpack.tsx
+++ b/sandpack-react/src/presets/Sandpack.tsx
@@ -10,7 +10,7 @@ import { SandpackTests } from "../components/Tests";
 import { SandpackLayout } from "../components/common/Layout";
 import { ConsoleIcon } from "../components/icons";
 import { SandpackProvider } from "../contexts/sandpackContext";
-import { css } from "../styles";
+import { css, THEME_PREFIX } from "../styles";
 import {
   buttonClassName,
   iconStandaloneClassName,
@@ -122,15 +122,12 @@ export const Sandpack: SandpackInternal = ({
   };
   const topRowStyle = hasRightColumn
     ? {
+        flexGrow: topPanelPreviewHeight,
+        flexShrink: topPanelPreviewHeight,
+        flexBasis: 0,
         overflow: "hidden",
-        flex: `${topPanelPreviewHeight} ${topPanelPreviewHeight} 0`,
       }
     : rightColumnStyle;
-  const bottomRowStyle = {
-    flexGrow: 100 - topPanelPreviewHeight,
-    flexShrink: 100 - topPanelPreviewHeight,
-    flexBasis: 0,
-  };
 
   const onDragMove = (event: MouseEvent): void => {
     if (!dragEventTargetRef.current) return;
@@ -216,7 +213,10 @@ export const Sandpack: SandpackInternal = ({
         />
 
         {/* @ts-ignore */}
-        <RightColumn style={rightColumnStyle}>
+        <RightColumn
+          className={THEME_PREFIX + "-preset-column"}
+          style={rightColumnStyle}
+        >
           {mode === "preview" && (
             <SandpackPreview
               actionsChildren={actionsChildren}
@@ -244,7 +244,16 @@ export const Sandpack: SandpackInternal = ({
                 style={{ top: `calc(${topPanelPreviewHeight}% - 5px)` }}
               />
 
-              <div className={consoleWrapper.toString()} style={bottomRowStyle}>
+              <div
+                className={consoleWrapper.toString()}
+                style={{
+                  flexGrow: consoleVisibility ? 100 - topPanelPreviewHeight : 0,
+                  flexShrink: consoleVisibility
+                    ? 100 - topPanelPreviewHeight
+                    : 0,
+                  flexBasis: 0,
+                }}
+              >
                 <SandpackConsole
                   onLogsChange={(logs): void => setCounter(logs.length)}
                   showHeader={false}

--- a/sandpack-react/src/presets/Sandpack.tsx
+++ b/sandpack-react/src/presets/Sandpack.tsx
@@ -106,24 +106,23 @@ export const Sandpack: SandpackInternal = ({
   /* eslint-disable @typescript-eslint/no-explicit-any */
   const dragEventTargetRef = React.useRef<any>(null);
 
-  const [editorWidth, setEditorWidth] = React.useState(
+  const [horizontalSize, setHorizontalSize] = React.useState(
     options.editorWidthPercentage
   );
-  const previewWidth = 100 - editorWidth;
-  const [topPanelPreviewHeight, setTopPanelPreviewHeight] = React.useState(70);
+  const [verticalSize, setVerticalSize] = React.useState(70);
 
   const RightColumn = hasRightColumn ? SandpackStack : React.Fragment;
   const rightColumnStyle = {
-    flexGrow: previewWidth,
-    flexShrink: previewWidth,
+    flexGrow: 100 - horizontalSize,
+    flexShrink: 100 - horizontalSize,
     flexBasis: 0,
     gap: consoleVisibility ? 1 : 0,
     height: options.editorHeight, // use the original editor height
   };
   const topRowStyle = hasRightColumn
     ? {
-        flexGrow: topPanelPreviewHeight,
-        flexShrink: topPanelPreviewHeight,
+        flexGrow: verticalSize,
+        flexShrink: verticalSize,
         flexBasis: 0,
         overflow: "hidden",
       }
@@ -132,36 +131,35 @@ export const Sandpack: SandpackInternal = ({
   const onDragMove = (event: MouseEvent): void => {
     if (!dragEventTargetRef.current) return;
 
-    const container = dragEventTargetRef.current.parentElement;
-    const direction = dragEventTargetRef.current.dataset.direction;
+    const container = dragEventTargetRef.current
+      .parentElement as HTMLDivElement;
+    const direction = dragEventTargetRef.current.dataset.direction as
+      | "horizontal"
+      | "vertical";
     const isHorizontal = direction === "horizontal";
 
-    if (!container) return;
-
     const { left, top, height, width } = container.getBoundingClientRect();
-
     const offset = isHorizontal
       ? ((event.clientX - left) / width) * 100
       : ((event.clientY - top) / height) * 100;
     const boundaries = Math.min(Math.max(offset, 25), 75);
 
     if (isHorizontal) {
-      setEditorWidth(boundaries);
+      setHorizontalSize(boundaries);
     } else {
-      setTopPanelPreviewHeight(boundaries);
+      setVerticalSize(boundaries);
     }
 
-    container.querySelectorAll("iframe").forEach((frame: HTMLIFrameElement) => {
+    container.querySelectorAll("iframe").forEach((frame) => {
       frame.style.pointerEvents = "none";
     });
   };
 
   const stopDragging = (): void => {
-    const container = dragEventTargetRef.current?.parentElement;
+    const container = dragEventTargetRef.current
+      ?.parentElement as HTMLDivElement;
 
-    if (!container) return;
-
-    container.querySelectorAll("iframe").forEach((frame: HTMLIFrameElement) => {
+    container.querySelectorAll("iframe").forEach((frame) => {
       frame.style.pointerEvents = "";
     });
 
@@ -196,8 +194,8 @@ export const Sandpack: SandpackInternal = ({
           {...codeEditorOptions}
           style={{
             height: options.editorHeight, // use the original editor height
-            flexGrow: editorWidth,
-            flexShrink: editorWidth,
+            flexGrow: horizontalSize,
+            flexShrink: horizontalSize,
             flexBasis: 0,
             overflow: "hidden",
           }}
@@ -209,7 +207,7 @@ export const Sandpack: SandpackInternal = ({
           onMouseDown={(event): void => {
             dragEventTargetRef.current = event.target;
           }}
-          style={{ left: `calc(${editorWidth}% - 5px)` }}
+          style={{ left: `calc(${horizontalSize}% - 5px)` }}
         />
 
         {/* @ts-ignore */}
@@ -241,16 +239,14 @@ export const Sandpack: SandpackInternal = ({
                 onMouseDown={(event): void => {
                   dragEventTargetRef.current = event.target;
                 }}
-                style={{ top: `calc(${topPanelPreviewHeight}% - 5px)` }}
+                style={{ top: `calc(${verticalSize}% - 5px)` }}
               />
 
               <div
                 className={consoleWrapper.toString()}
                 style={{
-                  flexGrow: consoleVisibility ? 100 - topPanelPreviewHeight : 0,
-                  flexShrink: consoleVisibility
-                    ? 100 - topPanelPreviewHeight
-                    : 0,
+                  flexGrow: consoleVisibility ? 100 - verticalSize : 0,
+                  flexShrink: consoleVisibility ? 100 - verticalSize : 0,
                   flexBasis: 0,
                 }}
               >

--- a/sandpack-react/src/presets/Sandpack.tsx
+++ b/sandpack-react/src/presets/Sandpack.tsx
@@ -28,20 +28,33 @@ import { classNames } from "../utils/classNames";
 /**
  * @hidden
  */
-export const Sandpack: SandpackInternal = (props) => {
+export const Sandpack: SandpackInternal = ({
+  options,
+  template,
+  customSetup,
+  files,
+  theme,
+  ...props
+}) => {
+  // fallback values
+  options ??= {};
+  options.resizablePanel ??= true;
+  options.editorWidthPercentage ??= 50;
+  options.showConsole ??= false;
+
   const codeEditorOptions: CodeEditorProps = {
-    showTabs: props.options?.showTabs,
-    showLineNumbers: props.options?.showLineNumbers,
-    showInlineErrors: props.options?.showInlineErrors,
-    wrapContent: props.options?.wrapContent,
-    closableTabs: props.options?.closableTabs,
-    initMode: props.options?.initMode,
-    extensions: props.options?.codeEditor?.extensions,
-    extensionsKeymap: props.options?.codeEditor?.extensionsKeymap,
-    readOnly: props.options?.readOnly,
-    showReadOnly: props.options?.showReadOnly,
-    id: props.options?.id,
-    additionalLanguages: props.options?.codeEditor?.additionalLanguages,
+    showTabs: options.showTabs,
+    showLineNumbers: options.showLineNumbers,
+    showInlineErrors: options.showInlineErrors,
+    wrapContent: options.wrapContent,
+    closableTabs: options.closableTabs,
+    initMode: options.initMode,
+    extensions: options.codeEditor?.extensions,
+    extensionsKeymap: options.codeEditor?.extensionsKeymap,
+    readOnly: options.readOnly,
+    showReadOnly: options.showReadOnly,
+    id: options.id,
+    additionalLanguages: options.codeEditor?.additionalLanguages,
   };
 
   const providerOptions: SandpackInternalOptions<
@@ -51,37 +64,36 @@ export const Sandpack: SandpackInternal = (props) => {
     /**
      * TS-why: Type 'string | number | symbol' is not assignable to type 'string'
      */
-    activeFile: props.options?.activeFile as unknown as string,
-    visibleFiles: props.options?.visibleFiles as unknown as string[],
-    recompileMode: props.options?.recompileMode,
-    recompileDelay: props.options?.recompileDelay,
-    autorun: props.options?.autorun,
-    bundlerURL: props.options?.bundlerURL,
-    startRoute: props.options?.startRoute,
-    skipEval: props.options?.skipEval,
-    fileResolver: props.options?.fileResolver,
-    initMode: props.options?.initMode,
-    initModeObserverOptions: props.options?.initModeObserverOptions,
-    externalResources: props.options?.externalResources,
-    logLevel: props.options?.logLevel,
-    classes: props.options?.classes,
+    activeFile: options.activeFile as unknown as string,
+    visibleFiles: options.visibleFiles as unknown as string[],
+    recompileMode: options.recompileMode,
+    recompileDelay: options.recompileDelay,
+    autorun: options.autorun,
+    bundlerURL: options.bundlerURL,
+    startRoute: options.startRoute,
+    skipEval: options.skipEval,
+    fileResolver: options.fileResolver,
+    initMode: options.initMode,
+    initModeObserverOptions: options.initModeObserverOptions,
+    externalResources: options.externalResources,
+    logLevel: options.logLevel,
+    classes: options.classes,
   };
 
   /**
    * Console
    */
   const [consoleVisibility, setConsoleVisibility] = React.useState(
-    props.options?.showConsole ?? false
+    options.showConsole
   );
   const [counter, setCounter] = React.useState(0);
-  const hasRightColumn =
-    props.options?.showConsole || props.options?.showConsoleButton;
+  const hasRightColumn = options.showConsole || options.showConsoleButton;
 
   /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-  const templateFiles = SANDBOX_TEMPLATES[props.template!] ?? {};
+  const templateFiles = SANDBOX_TEMPLATES[template!] ?? {};
   const mode = "mode" in templateFiles ? templateFiles.mode : "preview";
 
-  const actionsChildren = props.options?.showConsoleButton ? (
+  const actionsChildren = options.showConsoleButton ? (
     <ConsoleCounterButton
       counter={counter}
       onClick={(): void => setConsoleVisibility((prev) => !prev)}
@@ -95,7 +107,7 @@ export const Sandpack: SandpackInternal = (props) => {
   const dragEventTargetRef = React.useRef<any>(null);
 
   const [editorWidth, setEditorWidth] = React.useState(
-    props.options?.editorWidthPercentage || 50
+    options.editorWidthPercentage
   );
   const previewWidth = 100 - editorWidth;
   const [topPanelPreviewHeight, setTopPanelPreviewHeight] = React.useState(70);
@@ -106,7 +118,7 @@ export const Sandpack: SandpackInternal = (props) => {
     flexShrink: previewWidth,
     flexBasis: 0,
     gap: consoleVisibility ? 1 : 0,
-    height: props.options?.editorHeight, // use the original editor height
+    height: options.editorHeight, // use the original editor height
   };
   const topRowStyle = hasRightColumn
     ? {
@@ -115,12 +127,12 @@ export const Sandpack: SandpackInternal = (props) => {
       }
     : rightColumnStyle;
   const bottomRowStyle = {
-    flex: consoleVisibility
-      ? `${100 - topPanelPreviewHeight} ${100 - topPanelPreviewHeight} 0`
-      : 0,
+    flexGrow: 100 - topPanelPreviewHeight,
+    flexShrink: 100 - topPanelPreviewHeight,
+    flexBasis: 0,
   };
 
-  const onMove = (event: MouseEvent): void => {
+  const onDragMove = (event: MouseEvent): void => {
     if (!dragEventTargetRef.current) return;
 
     const container = dragEventTargetRef.current.parentElement;
@@ -160,32 +172,33 @@ export const Sandpack: SandpackInternal = (props) => {
   };
 
   React.useEffect(() => {
-    document.body.addEventListener("mousemove", onMove);
+    document.body.addEventListener("mousemove", onDragMove);
     document.body.addEventListener("mouseup", stopDragging);
 
     return (): void => {
-      document.body.removeEventListener("mousemove", onMove);
+      document.body.removeEventListener("mousemove", onDragMove);
       document.body.removeEventListener("mouseup", stopDragging);
     };
   }, []);
 
   React.useEffect(() => {
-    setConsoleVisibility(props.options?.showConsole ?? false);
-  }, [props.options?.showConsole]);
+    setConsoleVisibility(options?.showConsole ?? false);
+  }, [options.showConsole]);
 
   return (
     <SandpackProvider
-      customSetup={props.customSetup}
-      files={props.files as TemplateFiles<SandpackPredefinedTemplate>}
+      customSetup={customSetup}
+      files={files as TemplateFiles<SandpackPredefinedTemplate>}
       options={providerOptions}
-      template={props.template}
-      theme={props.theme}
+      template={template}
+      theme={theme}
+      {...props}
     >
       <SandpackLayout>
         <SandpackCodeEditor
           {...codeEditorOptions}
           style={{
-            height: props.options?.editorHeight, // use the original editor height
+            height: options.editorHeight, // use the original editor height
             flexGrow: editorWidth,
             flexShrink: editorWidth,
             flexBasis: 0,
@@ -199,7 +212,7 @@ export const Sandpack: SandpackInternal = (props) => {
           onMouseDown={(event): void => {
             dragEventTargetRef.current = event.target;
           }}
-          style={{ left: `${editorWidth}%` }}
+          style={{ left: `calc(${editorWidth}% - 5px)` }}
         />
 
         {/* @ts-ignore */}
@@ -207,8 +220,8 @@ export const Sandpack: SandpackInternal = (props) => {
           {mode === "preview" && (
             <SandpackPreview
               actionsChildren={actionsChildren}
-              showNavigator={props.options?.showNavigator}
-              showRefreshButton={props.options?.showRefreshButton}
+              showNavigator={options.showNavigator}
+              showRefreshButton={options.showRefreshButton}
               style={topRowStyle}
             />
           )}
@@ -220,7 +233,7 @@ export const Sandpack: SandpackInternal = (props) => {
             />
           )}
 
-          {(props.options?.showConsoleButton || consoleVisibility) && (
+          {(options.showConsoleButton || consoleVisibility) && (
             <>
               <div
                 className={dragHandler({ direction: "vertical" })}
@@ -228,7 +241,7 @@ export const Sandpack: SandpackInternal = (props) => {
                 onMouseDown={(event): void => {
                   dragEventTargetRef.current = event.target;
                 }}
-                style={{ top: `${topPanelPreviewHeight}%` }}
+                style={{ top: `calc(${topPanelPreviewHeight}% - 5px)` }}
               />
 
               <div className={consoleWrapper.toString()} style={bottomRowStyle}>
@@ -274,13 +287,13 @@ const dragHandler = css({
       vertical: {
         right: 0,
         left: 0,
-        height: 4,
+        height: 10,
         cursor: "ns-resize",
       },
       horizontal: {
         top: 0,
         bottom: 0,
-        width: 4,
+        width: 10,
         cursor: "ew-resize",
       },
     },

--- a/sandpack-react/src/presets/Sandpack.tsx
+++ b/sandpack-react/src/presets/Sandpack.tsx
@@ -202,7 +202,10 @@ export const Sandpack: SandpackInternal = ({
         />
 
         <div
-          className={dragHandler({ direction: "horizontal" })}
+          className={classNames(
+            dragHandler({ direction: "horizontal" }),
+            THEME_PREFIX + "-resize-handler"
+          )}
           data-direction="horizontal"
           onMouseDown={(event): void => {
             dragEventTargetRef.current = event.target;
@@ -233,17 +236,22 @@ export const Sandpack: SandpackInternal = ({
 
           {(options.showConsoleButton || consoleVisibility) && (
             <>
-              <div
-                className={dragHandler({ direction: "vertical" })}
-                data-direction="vertical"
-                onMouseDown={(event): void => {
-                  dragEventTargetRef.current = event.target;
-                }}
-                style={{ top: `calc(${verticalSize}% - 5px)` }}
-              />
+              {consoleVisibility && (
+                <div
+                  className={classNames(
+                    dragHandler({ direction: "vertical" }),
+                    THEME_PREFIX + "-resize-handler"
+                  )}
+                  data-direction="vertical"
+                  onMouseDown={(event): void => {
+                    dragEventTargetRef.current = event.target;
+                  }}
+                  style={{ top: `calc(${verticalSize}% - 5px)` }}
+                />
+              )}
 
               <div
-                className={consoleWrapper.toString()}
+                className={classNames(consoleWrapper)}
                 style={{
                   flexGrow: consoleVisibility ? 100 - verticalSize : 0,
                   flexShrink: consoleVisibility ? 100 - verticalSize : 0,

--- a/sandpack-react/src/presets/Sandpack.tsx
+++ b/sandpack-react/src/presets/Sandpack.tsx
@@ -81,12 +81,13 @@ export const Sandpack: SandpackInternal = (props) => {
     props.options?.editorWidthPercentage || 50
   );
   const previewPart = 100 - editorPart;
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   const dragEventTargetRef = React.useRef<any>(null);
 
   const hasRightColumn =
     props.options?.showConsole || props.options?.showConsoleButton;
   const RightColumn = hasRightColumn ? SandpackStack : React.Fragment;
-
   const rightColumnStyle = {
     flexGrow: previewPart,
     flexShrink: previewPart,
@@ -94,11 +95,6 @@ export const Sandpack: SandpackInternal = (props) => {
     gap: consoleVisibility ? 1 : 0,
     height: props.options?.editorHeight, // use the original editor height
   };
-
-  const rightColumnProps = React.useMemo(
-    () => (hasRightColumn ? { style: rightColumnStyle } : {}),
-    [hasRightColumn, previewPart]
-  );
 
   /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
   const templateFiles = SANDBOX_TEMPLATES[props.template!] ?? {};
@@ -185,25 +181,19 @@ export const Sandpack: SandpackInternal = (props) => {
         />
 
         {/* @ts-ignore */}
-        <RightColumn {...rightColumnProps}>
+        <RightColumn style={rightColumnStyle}>
           {mode === "preview" && (
             <SandpackPreview
               actionsChildren={actionsChildren}
               showNavigator={props.options?.showNavigator}
               showRefreshButton={props.options?.showRefreshButton}
-              style={{
-                ...(hasRightColumn ? {} : rightColumnStyle),
-                flex: hasRightColumn ? 1 : rightColumnStyle.flexGrow,
-              }}
+              style={hasRightColumn ? { flex: 1 } : rightColumnStyle}
             />
           )}
           {mode === "tests" && (
             <SandpackTests
               actionsChildren={actionsChildren}
-              style={{
-                ...(hasRightColumn ? {} : rightColumnStyle),
-                flex: hasRightColumn ? 1 : rightColumnStyle.flexGrow,
-              }}
+              style={hasRightColumn ? { flex: 1 } : rightColumnStyle}
             />
           )}
 

--- a/sandpack-react/src/presets/Sandpack.tsx
+++ b/sandpack-react/src/presets/Sandpack.tsx
@@ -91,7 +91,6 @@ export const Sandpack: SandpackInternal = (props) => {
     flexGrow: previewPart,
     flexShrink: previewPart,
     flexBasis: 0,
-    // minWidth: 700 * (previewPart / (previewPart + editorPart)),
     gap: consoleVisibility ? 1 : 0,
     height: props.options?.editorHeight, // use the original editor height
   };
@@ -116,7 +115,7 @@ export const Sandpack: SandpackInternal = (props) => {
     setConsoleVisibility(props.options?.showConsole ?? false);
   }, [props.options?.showConsole]);
 
-  const onMove = (event) => {
+  const onMove = (event: MouseEvent): void => {
     if (!drag.current) return;
 
     const pointerOffset = event.clientX;
@@ -135,7 +134,7 @@ export const Sandpack: SandpackInternal = (props) => {
       drag.current = false;
     });
 
-    return () => {
+    return (): void => {
       document.body.removeEventListener("mousemove", onMove);
     };
   }, []);
@@ -155,24 +154,18 @@ export const Sandpack: SandpackInternal = (props) => {
             height: props.options?.editorHeight, // use the original editor height
             flexGrow: editorPart,
             flexShrink: editorPart,
-            minWidth: 700 * (editorPart / (previewPart + editorPart)),
           }}
         />
 
         <div
-          className="handler"
-          onMouseDown={() => (drag.current = true)}
-          onMouseUp={() => (drag.current = false)}
-          style={{
-            position: "absolute",
-            left: `calc(${editorPart}% - 10px)`,
-            top: 0,
-            bottom: 0,
-            width: 20,
-            // background: "red",
-            zIndex: 9999,
-            cursor: "ew-resize",
+          className={classNames(handler)}
+          onMouseDown={(): void => {
+            drag.current = true;
           }}
+          onMouseUp={(): void => {
+            drag.current = false;
+          }}
+          style={{ left: `calc(${editorPart}% - 10px)` }}
         />
 
         {/* @ts-ignore */}
@@ -236,6 +229,16 @@ const ConsoleCounterButton: React.FC<{
     </button>
   );
 };
+
+const handler = css({
+  position: "absolute",
+  top: 0,
+  bottom: 0,
+  width: 20,
+  // background: "red",
+  zIndex: 9999,
+  cursor: "ew-resize",
+});
 
 const buttonCounter = css({
   position: "relative",

--- a/sandpack-react/src/presets/Sandpack.tsx
+++ b/sandpack-react/src/presets/Sandpack.tsx
@@ -310,7 +310,6 @@ const buttonCounter = css({
 });
 
 const consoleWrapper = css({
-  // transition: "flex $transitions$default",
   width: "100%",
   overflow: "hidden",
 });

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -108,6 +108,7 @@ export interface SandpackOptions {
   showConsole?: boolean;
   closableTabs?: boolean;
   wrapContent?: boolean;
+  resizablePanel?: boolean;
 
   codeEditor?: SandpackCodeOptions;
 
@@ -477,6 +478,7 @@ interface SandpackInternalProps<
     showConsole?: boolean;
     closableTabs?: boolean;
     wrapContent?: boolean;
+    resizablePanel?: boolean;
 
     codeEditor?: SandpackCodeOptions;
 

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -108,7 +108,7 @@ export interface SandpackOptions {
   showConsole?: boolean;
   closableTabs?: boolean;
   wrapContent?: boolean;
-  resizablePanel?: boolean;
+  resizablePanels?: boolean;
 
   codeEditor?: SandpackCodeOptions;
 
@@ -478,7 +478,7 @@ interface SandpackInternalProps<
     showConsole?: boolean;
     closableTabs?: boolean;
     wrapContent?: boolean;
-    resizablePanel?: boolean;
+    resizablePanels?: boolean;
 
     codeEditor?: SandpackCodeOptions;
 

--- a/website/docs/docs/getting-started/custom-ui.md
+++ b/website/docs/docs/getting-started/custom-ui.md
@@ -132,6 +132,19 @@ experience by modifying the `recompileDelay` value or by setting the
 />
 ```
 
+### Resizable panels
+
+The `<Sandpack />` preset component has resizable columns and rows by default, allowing users to extend and shrink the component sizes. This makes it easier to play with the preview component and shows more code-editor content. However, this is an optional configuration, and you can easily disable it: 
+
+```jsx
+<Sandpack
+  options={{
+    resizablePanels: false,
+  }}
+  template="react"
+/>
+```
+
 ---
 
 :::success Congrats!

--- a/website/docs/docs/getting-started/custom-ui.md
+++ b/website/docs/docs/getting-started/custom-ui.md
@@ -137,12 +137,7 @@ experience by modifying the `recompileDelay` value or by setting the
 The `<Sandpack />` preset component has resizable columns and rows by default, allowing users to extend and shrink the component sizes. This makes it easier to play with the preview component and shows more code-editor content. However, this is an optional configuration, and you can easily disable it: 
 
 ```jsx
-<Sandpack
-  options={{
-    resizablePanels: false,
-  }}
-  template="react"
-/>
+<Sandpack options={{ resizablePanels: false }} />
 ```
 
 ---

--- a/website/docs/src/scss/_code.scss
+++ b/website/docs/src/scss/_code.scss
@@ -18,6 +18,10 @@ pre {
   }
 }
 
+.nestedSandpack .sp-resize-handler {
+  display: none;
+}
+
 .nestedSandpack > .sp-wrapper > .sp-layout {
   display: block;
 }


### PR DESCRIPTION
This introduces the ability to resize the columns and rows on `<Sandpack />` (preset component):
- Desktop only: which means that mobile or touch devices don't support resizing panels in order to keep the usability accessible as the drag handler is not visible for non-cursor pointers;
- Boundaries: columns and rows have a minimum of 25% size and a max of 75%;

Plus, this PR introduces other improvements which aim to solve some layout issues on small-screen devices (set min-height for standard components), and other things to reduce the bundle size. 

Todo
- [x] Docs: remove handler for nested Sandpack layout;
- [x] Docs: document `resizablePanels` prop;
- [x] Rows handler: hide handler when vertical panel is collapsed (console panel is hidden);

Preview: https://2075ed-6006.preview.csb.app/iframe.html?id=intro-playground--preset&args=&viewMode=story