### PR TITLE
fix(client): set iframe capabilities

### DIFF
--- a/sandpack-client/src/client.ts
+++ b/sandpack-client/src/client.ts
@@ -164,6 +164,11 @@ export class SandpackClient {
         "sandbox",
         "allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
       );
+
+      this.iframe.setAttribute(
+        "allow",
+        "accelerometer; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi;"
+      );
     }
 
     this.setLocationURLIntoIFrame();


### PR DESCRIPTION
It allows iframe to use some specific browser API, such as: accelerometer; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi;

Closes #681