### PR TITLE
fix(iframe): set `src` attribute 

### DIFF
--- a/sandpack-client/src/client.ts
+++ b/sandpack-client/src/client.ts
@@ -3,7 +3,7 @@ import isEqual from "lodash.isequal";
 
 import Protocol from "./file-resolver-protocol";
 import { IFrameProtocol } from "./iframe-protocol";
-import {
+import type {
   Dependencies,
   SandpackBundlerFiles,
   BundlerState,
@@ -16,8 +16,8 @@ import {
   ReactDevToolsMode,
   Template,
   NpmRegistry,
-  SandpackLogLevel,
 } from "./types";
+import { SandpackLogLevel } from "./types";
 import {
   createPackageJSON,
   addPackageJSONIfNeeded,
@@ -236,6 +236,7 @@ export class SandpackClient {
       : this.bundlerURL;
 
     this.iframe.contentWindow?.location.replace(urlSource);
+    this.iframe.src = urlSource;
   }
 
   cleanup(): void {

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -284,12 +284,5 @@ test('renders welcome message', () => {
 };
 
 export const Basic: React.FC = () => {
-  return (
-    <Sandpack
-      files={{
-        "/src/index.js": `navigator.mediaDevices.getUserMedia({ audio: true }) `,
-      }}
-      template="vanilla"
-    />
-  );
+  return <Sandpack />;
 };

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -286,12 +286,10 @@ test('renders welcome message', () => {
 export const Basic: React.FC = () => {
   return (
     <Sandpack
-      options={{
-        // showConsole: true,
-        showConsoleButton: false,
-        // editorHeight: 500,
+      files={{
+        "/src/index.js": `navigator.mediaDevices.getUserMedia({ audio: true }) `,
       }}
-      template="vite-react"
+      template="vanilla"
     />
   );
 };

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -449,6 +449,7 @@ export class SandpackProviderClass extends React.PureComponent<
     if (client) {
       client.cleanup();
       client.iframe.contentWindow?.location.replace("about:blank");
+      client.iframe.removeAttribute("src");
       delete this.clients[clientId];
     } else {
       delete this.preregisteredIframes[clientId];


### PR DESCRIPTION
This reverts https://github.com/codesandbox/sandpack/pull/407, which is used to prevent Firefox from adding a new page to the main browser history. However, it seems that it's blocking other users from accessing some browser APIs (see #686). 

Let's give it another try and keep an eye out if the issue is still happening on Firefox, I hope it doesn't. 

Fix #686