### PR TITLE
fix: website docs sandpack wrapper style

### DIFF
--- a/website/docs/src/scss/_code.scss
+++ b/website/docs/src/scss/_code.scss
@@ -22,6 +22,10 @@ pre {
   display: none;
 }
 
+.nestedSandpack > .sp-wrapper > .sp-layout .sp-stack {
+  width: inherit !important;
+}
+
 .nestedSandpack > .sp-wrapper > .sp-layout {
   display: block;
 }


### PR DESCRIPTION
## What is the current behavior?

https://sandpack.codesandbox.io/docs/getting-started/install

<img width="912" alt="image" src="https://user-images.githubusercontent.com/12525415/215638556-93e4ca82-7fe6-4d60-958e-810b74ba701d.png">

## What is the new behavior?

`website/docs/src/scss/_code.scss`

```diff
+ .nestedSandpack > .sp-wrapper > .sp-layout .sp-stack {
+   width: inherit !important;
+ }
```

<img width="921" alt="image" src="https://user-images.githubusercontent.com/12525415/215638722-a01003d4-8833-4ad3-84dd-154529ed61df.png">

## Checklist

- [x] Documentation;
- [ ] Storybook (if applicable);
- [ ] Tests;
- [x] Ready to be merged;

@danilowoz 