### PR TITLE
fix: file explorer style in mobile

### DIFF
--- a/sandpack-react/src/components/CodeEditor/utils.ts
+++ b/sandpack-react/src/components/CodeEditor/utils.ts
@@ -5,8 +5,8 @@ import type { LanguageSupport } from "@codemirror/language";
 import { HighlightStyle } from "@codemirror/language";
 import type { Extension, Text } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import * as React from "react";
 import { tags } from "@lezer/highlight";
+import * as React from "react";
 
 import { THEME_PREFIX } from "../../styles";
 import type { CustomLanguage, SandpackTheme } from "../../types";

--- a/sandpack-react/src/components/FileExplorer/Directory.tsx
+++ b/sandpack-react/src/components/FileExplorer/Directory.tsx
@@ -1,10 +1,12 @@
 import type { SandpackBundlerFiles } from "@codesandbox/sandpack-client";
 import * as React from "react";
 
-import type { SandpackFileExplorerProp } from ".";
-import { SandpackOptions } from "../../types";
+import type { SandpackOptions } from "../../types";
+
 import { File } from "./File";
 import { ModuleList } from "./ModuleList";
+
+import type { SandpackFileExplorerProp } from ".";
 
 export interface Props extends SandpackFileExplorerProp {
   prefixedPath: string;

--- a/sandpack-react/src/components/common/Layout.tsx
+++ b/sandpack-react/src/components/common/Layout.tsx
@@ -54,6 +54,11 @@ export const layoutClassName = css({
   [`> .${THEME_PREFIX}-file-explorer`]: {
     flex: 0.2,
     minWidth: 200,
+    "@media screen and (max-width: 768px)": {
+      "&": {
+        minWidth: "100% !important",
+      },
+    },
   },
 });
 

--- a/sandpack-react/src/contexts/sandpackContext.test.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.test.tsx
@@ -57,8 +57,8 @@ describe(SandpackProvider, () => {
     it("deletes the activeFile and set the following visibleFile as active", () => {
       const root = create(
         <SandpackProvider
-          template="react"
           options={{ activeFile: "/App.js", visibleFiles: ["/styles.css"] }}
+          template="react"
         />
       );
 
@@ -73,8 +73,8 @@ describe(SandpackProvider, () => {
     it("deletes the activeFile and set the entry file if there no visibleFile left", () => {
       const root = create(
         <SandpackProvider
-          template="react"
           options={{ activeFile: "/App.js", visibleFiles: [] }}
+          template="react"
         />
       );
 

--- a/sandpack-react/src/hooks/useSandpackClient.ts
+++ b/sandpack-react/src/hooks/useSandpackClient.ts
@@ -8,6 +8,7 @@ import * as React from "react";
 
 import type { SandpackState } from "../types";
 import { generateRandomId } from "../utils/stringUtils";
+
 import { useSandpack } from "./useSandpack";
 
 interface UseSandpackClient {


### PR DESCRIPTION
## What is the current behavior?

```jsx
<SandpackProvider template="react">
    <SandpackLayout>
        <SandpackFileExplorer />
        <SandpackCodeEditor closableTabs  />
        <SandpackPreview />
    </SandpackLayout>
</SandpackProvider>
```

<img width="356" alt="image" src="https://user-images.githubusercontent.com/12525415/215644501-cad6c7f1-5628-453e-96bd-2cee151f9ab4.png">

## What is the new behavior?

`sandpack-react/src/components/common/Layout.tsx`

```diff
[`> .${THEME_PREFIX}-file-explorer`]: {
    flex: 0.2,
    minWidth: 200,
+    "@media screen and (max-width: 768px)": {
+      "&": {
+       minWidth: "100% !important",
+     },
+   },
  },
```

<img width="362" alt="image" src="https://user-images.githubusercontent.com/12525415/215644675-9a161b58-d504-4d32-a204-79a150801ab4.png">

## Checklist

- [x] Sandpack-react
- [x] Ready to be merged;
