### PR TITLE
fix(react-vite template): use automatic runtime for jsx

### DIFF
--- a/sandpack-react/src/templates/node/vite-react.ts
+++ b/sandpack-react/src/templates/node/vite-react.ts
@@ -4,9 +4,7 @@ export const VITE_REACT_TEMPLATE = {
   files: {
     ...commonFiles,
     "/App.jsx": {
-      code: `import React from "react"
-
-export default function App() {
+      code: `export default function App() {
   const data = "world"
 
   return <h1>Hello {data}</h1>
@@ -14,7 +12,7 @@ export default function App() {
 `,
     },
     "/index.jsx": {
-      code: `import React, { StrictMode } from "react";
+      code: `import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./styles.css";
 
@@ -42,7 +40,6 @@ root.render(
 </html>
 `,
     },
-
     "/package.json": {
       code: JSON.stringify({
         scripts: {
@@ -55,10 +52,21 @@ root.render(
           "react-dom": "^18.2.0",
         },
         devDependencies: {
+          "@vitejs/plugin-react": "3.1.0",
           vite: "4.0.0",
           "esbuild-wasm": "0.15.12",
         },
       }),
+    },
+    "/vite.config.js": {
+      code: `import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+});
+`,
     },
   },
   main: "/App.jsx",


### PR DESCRIPTION
I implemented automatic runtime for VITE-REACT template.

<details>
  <summary> 🤯🤯🤯 </summary>
  This is magic, it works in the browser
</details>



