### PR TITLE
fix(sandpack-client): move console-feed to dev deps

### DIFF
--- a/sandpack-client/package.json
+++ b/sandpack-client/package.json
@@ -47,13 +47,13 @@
   ],
   "dependencies": {
     "@codesandbox/nodebox": "0.1.0",
-    "console-feed": "3.3.0",
     "lodash.isequal": "^4.5.0",
     "outvariant": "1.3.0"
   },
   "devDependencies": {
     "@types/lodash.isequal": "^4.5.2",
     "@types/node": "^9.3.0",
+    "console-feed": "3.3.0",
     "del": "^6.0.0",
     "gulp": "^4.0.2",
     "typescript": "4.0.3"


### PR DESCRIPTION
move `console-feed` to dev deps to fix warnings about peer dependencies, like this:

`warning "@codesandbox/sandpack-client > console-feed > linkifyjs@2.1.9" has unmet peer dependency "jquery@>= 1.11.0".`

This is safe because `console-feed` is bundled into a string, so end users don't need to install it

To test install `@codesandbox/sandpack-client` with `yarn`