### PR TITLE
Correct yarn install command on Getting Started

### DIFF
--- a/website/docs/src/pages/getting-started/index.mdx
+++ b/website/docs/src/pages/getting-started/index.mdx
@@ -7,18 +7,20 @@ import { CodeBlock } from "../../components/CodeBlock";
 Install the Sandpack dependency on your project.
 
 <Tabs items={["npm", "yarn", "pnpm"]}>
-  <Tab>  
+  <Tab>
 ```shell
 npm i @codesandbox/sandpack-react
 ```
   </Tab>
 
-{" "}
-
-<Tab>```bash yarn i @codesandbox/sandpack-react ```</Tab>
+  <Tab>
+```shell
+yarn add @codesandbox/sandpack-react
+```
+  </Tab>
 
   <Tab>
-    ```bash
+```shell
 pnpm i @codesandbox/sandpack-react 
 ```
   </Tab>


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Minor documentation update (code syntax and markdown formatting).

## What is the current behavior?

Yarn installation instructions are incorrect and formatted incorrectly.

## What is the new behavior?

Formatting and command syntax is fixed.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

N/A

## Checklist

- [x] Documentation;
- [ ] Storybook (if applicable); N/A
- [ ] Tests; N/A
- [x] Ready to be merged;

npm instructions are formatted like a full code block:

![image](https://user-images.githubusercontent.com/366438/220396055-62f79e1c-bfb4-47df-bca7-42cbf32aeb3e.png)

but yarn instructions are formatted like an inline code block, and `yarn i` should be `yarn add`:

![image](https://user-images.githubusercontent.com/366438/220396198-1edd6be4-6015-4f0a-bd74-67cf8994ec56.png)
