### PR TITLE
fix(sandpack-tests): introduce `hideTestsAndSupressLogs` prop

### DIFF
--- a/sandpack-react/rollup.config.js
+++ b/sandpack-react/rollup.config.js
@@ -29,7 +29,7 @@ const configBase = {
     commonjs({ requireReturnsDefault: "preferred" }),
   ],
   external: [
-    'react/jsx-runtime',
+    "react/jsx-runtime",
     ...Object.keys(pkg.dependencies),
     ...Object.keys(pkg.devDependencies),
     ...Object.keys(pkg.peerDependencies),

--- a/sandpack-react/src/components/Tests/Header.tsx
+++ b/sandpack-react/src/components/Tests/Header.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 
-import { useSandpack } from "../../hooks";
 import { css } from "../../styles";
 import { buttonClassName, roundedButtonClassName } from "../../styles/shared";
 import { classNames } from "../../utils/classNames";
@@ -35,8 +34,9 @@ interface Props {
   watchMode: boolean;
   setWatchMode: () => void;
   showSuitesOnly: boolean;
-  hideVerboseButton?: boolean;
-  hideWatchButton?: boolean;
+  showVerboseButton?: boolean;
+  showWatchButton?: boolean;
+  hideTestsAndSupressLogs?: boolean;
 }
 
 const buttonsClassName = classNames(
@@ -54,10 +54,10 @@ export const Header: React.FC<Props> = ({
   watchMode,
   setWatchMode,
   showSuitesOnly,
-  hideVerboseButton,
-  hideWatchButton,
+  showWatchButton,
+  showVerboseButton,
+  hideTestsAndSupressLogs,
 }) => {
-  const {sandpack} = useSandpack()
   return (
     <div className={classNames(wrapperClassName, flexClassName)}>
       <div className={classNames(flexClassName)}>
@@ -93,18 +93,18 @@ export const Header: React.FC<Props> = ({
             Suite only
           </button>
         )}
-        {!hideVerboseButton && ! (
+        {showVerboseButton && (
           <button
             className={buttonsClassName}
             data-active={verbose}
-            disabled={status === "initialising" ||sandpack.hideTestsAndSupressLogs}
+            disabled={status === "initialising" || hideTestsAndSupressLogs}
             onClick={setVerbose}
             type="button"
           >
             Verbose
           </button>
         )}
-        {!hideWatchButton && (
+        {showWatchButton && (
           <button
             className={buttonsClassName}
             data-active={watchMode}

--- a/sandpack-react/src/components/Tests/Header.tsx
+++ b/sandpack-react/src/components/Tests/Header.tsx
@@ -34,9 +34,9 @@ interface Props {
   watchMode: boolean;
   setWatchMode: () => void;
   showSuitesOnly: boolean;
-  showVerboseButton?: boolean;
-  showWatchButton?: boolean;
-  hideTestsAndSupressLogs?: boolean;
+  showVerboseButton: boolean;
+  showWatchButton: boolean;
+  hideTestsAndSupressLogs: boolean;
 }
 
 const buttonsClassName = classNames(

--- a/sandpack-react/src/components/Tests/Header.tsx
+++ b/sandpack-react/src/components/Tests/Header.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { css } from "../../styles";
-import { roundedButtonClassName, buttonClassName } from "../../styles/shared";
+import { buttonClassName, roundedButtonClassName } from "../../styles/shared";
 import { classNames } from "../../utils/classNames";
 import { ConsoleIcon } from "../icons";
 
@@ -34,6 +34,8 @@ interface Props {
   watchMode: boolean;
   setWatchMode: () => void;
   showSuitesOnly: boolean;
+  hideVerboseButton?: boolean;
+  hideWatchButton?: boolean;
 }
 
 const buttonsClassName = classNames(
@@ -51,6 +53,8 @@ export const Header: React.FC<Props> = ({
   watchMode,
   setWatchMode,
   showSuitesOnly,
+  hideVerboseButton,
+  hideWatchButton,
 }) => {
   return (
     <div className={classNames(wrapperClassName, flexClassName)}>
@@ -87,24 +91,28 @@ export const Header: React.FC<Props> = ({
             Suite only
           </button>
         )}
-        <button
-          className={buttonsClassName}
-          data-active={verbose}
-          disabled={status === "initialising"}
-          onClick={setVerbose}
-          type="button"
-        >
-          Verbose
-        </button>
-        <button
-          className={buttonsClassName}
-          data-active={watchMode}
-          disabled={status === "initialising"}
-          onClick={setWatchMode}
-          type="button"
-        >
-          Watch
-        </button>
+        {!hideVerboseButton && (
+          <button
+            className={buttonsClassName}
+            data-active={verbose}
+            disabled={status === "initialising"}
+            onClick={setVerbose}
+            type="button"
+          >
+            Verbose
+          </button>
+        )}
+        {!hideWatchButton && (
+          <button
+            className={buttonsClassName}
+            data-active={watchMode}
+            disabled={status === "initialising"}
+            onClick={setWatchMode}
+            type="button"
+          >
+            Watch
+          </button>
+        )}
       </div>
     </div>
   );

--- a/sandpack-react/src/components/Tests/Header.tsx
+++ b/sandpack-react/src/components/Tests/Header.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { useSandpack } from "../../hooks";
 import { css } from "../../styles";
 import { buttonClassName, roundedButtonClassName } from "../../styles/shared";
 import { classNames } from "../../utils/classNames";
@@ -56,6 +57,7 @@ export const Header: React.FC<Props> = ({
   hideVerboseButton,
   hideWatchButton,
 }) => {
+  const {sandpack} = useSandpack()
   return (
     <div className={classNames(wrapperClassName, flexClassName)}>
       <div className={classNames(flexClassName)}>
@@ -91,11 +93,11 @@ export const Header: React.FC<Props> = ({
             Suite only
           </button>
         )}
-        {!hideVerboseButton && (
+        {!hideVerboseButton && ! (
           <button
             className={buttonsClassName}
             data-active={verbose}
-            disabled={status === "initialising"}
+            disabled={status === "initialising" ||sandpack.hideTestsAndSupressLogs}
             onClick={setVerbose}
             type="button"
           >

--- a/sandpack-react/src/components/Tests/SandpackTests.tsx
+++ b/sandpack-react/src/components/Tests/SandpackTests.tsx
@@ -74,9 +74,9 @@ export const SandpackTests: React.FC<
   className,
   onComplete,
   actionsChildren,
-  showVerboseButton,
-  showWatchButton,
-  hideTestsAndSupressLogs,
+  showVerboseButton=true,
+  showWatchButton = true,
+  hideTestsAndSupressLogs=false,
   ...props
 }) => {
   const theme = useSandpackTheme();

--- a/sandpack-react/src/components/Tests/SandpackTests.tsx
+++ b/sandpack-react/src/components/Tests/SandpackTests.tsx
@@ -74,9 +74,9 @@ export const SandpackTests: React.FC<
   className,
   onComplete,
   actionsChildren,
-  showVerboseButton=true,
+  showVerboseButton = true,
   showWatchButton = true,
-  hideTestsAndSupressLogs=false,
+  hideTestsAndSupressLogs = false,
   ...props
 }) => {
   const theme = useSandpackTheme();

--- a/sandpack-react/src/components/Tests/SandpackTests.tsx
+++ b/sandpack-react/src/components/Tests/SandpackTests.tsx
@@ -58,6 +58,8 @@ export const SandpackTests: React.FC<
     watchMode?: boolean;
     onComplete?: (specs: Record<string, Spec>) => void;
     actionsChildren?: JSX.Element;
+    hideVerboseButton?:boolean
+    hideWatchButton?:boolean;
   } & React.HtmlHTMLAttributes<HTMLDivElement>
 > = ({
   verbose = false,
@@ -66,6 +68,8 @@ export const SandpackTests: React.FC<
   className,
   onComplete,
   actionsChildren,
+  hideVerboseButton,
+  hideWatchButton,
   ...props
 }) => {
   const theme = useSandpackTheme();
@@ -379,6 +383,8 @@ export const SandpackTests: React.FC<
       <iframe ref={iframe} style={{ display: "none" }} title="Sandpack Tests" />
 
       <Header
+        hideVerboseButton={hideVerboseButton}
+        hideWatchButton={hideWatchButton}
         setSuiteOnly={(): void =>
           setState((s) => ({ ...s, suiteOnly: !s.suiteOnly }))
         }

--- a/sandpack-react/src/components/Tests/SandpackTests.tsx
+++ b/sandpack-react/src/components/Tests/SandpackTests.tsx
@@ -58,8 +58,14 @@ export const SandpackTests: React.FC<
     watchMode?: boolean;
     onComplete?: (specs: Record<string, Spec>) => void;
     actionsChildren?: JSX.Element;
-    hideVerboseButton?:boolean
-    hideWatchButton?:boolean;
+    showVerboseButton?: boolean;
+    showWatchButton?: boolean;
+    /**
+     * Hide the tests and supress logs
+     * If `true` the tests will be hidden and the logs will be supressed. This is useful when you want to run tests in the background and don't want to show the tests to the user.
+     * @default false
+     */
+    hideTestsAndSupressLogs?: boolean;
   } & React.HtmlHTMLAttributes<HTMLDivElement>
 > = ({
   verbose = false,
@@ -68,8 +74,9 @@ export const SandpackTests: React.FC<
   className,
   onComplete,
   actionsChildren,
-  hideVerboseButton,
-  hideWatchButton,
+  showVerboseButton,
+  showWatchButton,
+  hideTestsAndSupressLogs,
   ...props
 }) => {
   const theme = useSandpackTheme();
@@ -383,8 +390,7 @@ export const SandpackTests: React.FC<
       <iframe ref={iframe} style={{ display: "none" }} title="Sandpack Tests" />
 
       <Header
-        hideVerboseButton={hideVerboseButton}
-        hideWatchButton={hideWatchButton}
+        hideTestsAndSupressLogs={hideTestsAndSupressLogs}
         setSuiteOnly={(): void =>
           setState((s) => ({ ...s, suiteOnly: !s.suiteOnly }))
         }
@@ -395,6 +401,8 @@ export const SandpackTests: React.FC<
           setState((s) => ({ ...s, watchMode: !s.watchMode }));
         }}
         showSuitesOnly={state.specsCount > 1}
+        showVerboseButton={showVerboseButton}
+        showWatchButton={showWatchButton}
         status={state.status}
         suiteOnly={state.suiteOnly}
         verbose={state.verbose}
@@ -424,6 +432,7 @@ export const SandpackTests: React.FC<
         ) : (
           <>
             <Specs
+              hideTestsAndSupressLogs={hideTestsAndSupressLogs}
               openSpec={openSpec}
               specs={specs}
               status={state.status}

--- a/sandpack-react/src/components/Tests/Specs.tsx
+++ b/sandpack-react/src/components/Tests/Specs.tsx
@@ -1,7 +1,6 @@
 import type { TestError } from "@codesandbox/sandpack-client";
 import * as React from "react";
 
-import { useSandpack } from "../../hooks";
 import { css } from "../../styles";
 import { buttonClassName } from "../../styles/shared";
 import { classNames } from "../../utils/classNames";
@@ -26,6 +25,7 @@ interface Props {
   verbose: boolean;
   status: Status;
   openSpec: (name: string) => void;
+  hideTestsAndSupressLogs?: boolean;
 }
 
 const fileContainer = css({
@@ -78,9 +78,8 @@ export const Specs: React.FC<Props> = ({
   openSpec,
   status,
   verbose,
+  hideTestsAndSupressLogs,
 }) => {
-  const { sandpack } = useSandpack();
-  const hideFailingTests = sandpack?.hideTestsAndSupressLogs;
   return (
     <>
       {specs.map((spec) => {
@@ -93,9 +92,7 @@ export const Specs: React.FC<Props> = ({
                 Error
               </SpecLabel>
               <FilePath
-                onClick={(): void =>
-                  openSpec(spec.name)
-                }
+                onClick={(): void => openSpec(spec.name)}
                 path={spec.name}
               />
               <FormattedError error={spec.error} path={spec.name} />
@@ -144,19 +141,21 @@ export const Specs: React.FC<Props> = ({
 
               <FilePath
                 onClick={(): void => {
-                  if(!hideFailingTests){
-                    openSpec(spec.name)
+                  if (!hideTestsAndSupressLogs) {
+                    openSpec(spec.name);
                   }
                 }}
                 path={spec.name}
               />
             </div>
 
-            {verbose &&!hideFailingTests && <Tests tests={tests} />}
+            {verbose && !hideTestsAndSupressLogs && <Tests tests={tests} />}
 
-            {verbose &&!hideFailingTests && <Describes describes={describes} />}
+            {verbose && !hideTestsAndSupressLogs && (
+              <Describes describes={describes} />
+            )}
 
-            {!hideFailingTests &&
+            {!hideTestsAndSupressLogs &&
               getFailingTests(spec).map((test) => {
                 return (
                   <div

--- a/sandpack-react/src/components/Tests/Specs.tsx
+++ b/sandpack-react/src/components/Tests/Specs.tsx
@@ -80,7 +80,7 @@ export const Specs: React.FC<Props> = ({
   verbose,
 }) => {
   const { sandpack } = useSandpack();
-  const hideFailingTests = sandpack?.testOptions?.hideTestsAndSupressLogs;
+  const hideFailingTests = sandpack?.hideTestsAndSupressLogs;
   return (
     <>
       {specs.map((spec) => {

--- a/sandpack-react/src/components/Tests/Summary.tsx
+++ b/sandpack-react/src/components/Tests/Summary.tsx
@@ -6,7 +6,7 @@ import { classNames } from "../../utils/classNames";
 import {
   failTextClassName,
   passTextClassName,
-  skipTextClassName,
+  skipTextClassName
 } from "./style";
 
 export interface TestResults {
@@ -44,7 +44,7 @@ const containerClassName = css({
 
 export const Summary: React.FC<Props> = ({ suites, tests, duration }) => {
   const widestLabel = "Test suites: ";
-
+ 
   const withMargin = (label: string): string => {
     const difference = widestLabel.length - label.length;
     const margin = Array.from({ length: difference }, () => " ").join("");

--- a/sandpack-react/src/components/Tests/Summary.tsx
+++ b/sandpack-react/src/components/Tests/Summary.tsx
@@ -6,7 +6,7 @@ import { classNames } from "../../utils/classNames";
 import {
   failTextClassName,
   passTextClassName,
-  skipTextClassName
+  skipTextClassName,
 } from "./style";
 
 export interface TestResults {
@@ -44,7 +44,7 @@ const containerClassName = css({
 
 export const Summary: React.FC<Props> = ({ suites, tests, duration }) => {
   const widestLabel = "Test suites: ";
- 
+
   const withMargin = (label: string): string => {
     const difference = widestLabel.length - label.length;
     const margin = Array.from({ length: difference }, () => " ").join("");

--- a/sandpack-react/src/components/Tests/Tests.stories.tsx
+++ b/sandpack-react/src/components/Tests/Tests.stories.tsx
@@ -147,6 +147,31 @@ export const VerboseMode: React.FC = () => {
   );
 };
 
+export const HiddenTests: React.FC = () => {
+  return (
+    <SandpackProvider
+      customSetup={{ entry: "add.ts" }}
+      files={{
+        "/add.test.ts": addTests,
+        "/add.ts": add,
+        "/src/app/sub.ts": sub,
+        "/src/app/sub.test.ts": subTests,
+      }}
+      options={{
+        testOptions:{
+          hideTestsAndSupressLogs:true
+        }
+      }}
+      theme={dracula}
+    >
+      <SandpackLayout  style={{ "--sp-layout-height": "70vh" } as CSSProperties}>
+        <SandpackCodeEditor showRunButton={false} showLineNumbers />
+        <SandpackTests />
+      </SandpackLayout>
+    </SandpackProvider>
+  );
+};
+
 export const OneTestFile: React.FC = () => {
   return (
     <SandpackProvider

--- a/sandpack-react/src/components/Tests/Tests.stories.tsx
+++ b/sandpack-react/src/components/Tests/Tests.stories.tsx
@@ -147,6 +147,12 @@ export const VerboseMode: React.FC = () => {
   );
 };
 
+/**
+ * This story is used to test the `hideTestsAndSupressLogs` option.
+ * Tests content should not be visible in the tests console.
+ * It is useful when you want to hide the tests from the user.
+ *  
+ */
 export const HiddenTests: React.FC = () => {
   return (
     <SandpackProvider
@@ -158,15 +164,14 @@ export const HiddenTests: React.FC = () => {
         "/src/app/sub.test.ts": subTests,
       }}
       options={{
-        testOptions:{
-          hideTestsAndSupressLogs:true
-        }
+        hideTestsAndSupressLogs:true,
+        visibleFiles: ["/add.ts"],
       }}
       theme={dracula}
     >
       <SandpackLayout  style={{ "--sp-layout-height": "70vh" } as CSSProperties}>
         <SandpackCodeEditor showRunButton={false} showLineNumbers />
-        <SandpackTests />
+        <SandpackTests verbose/>
       </SandpackLayout>
     </SandpackProvider>
   );

--- a/sandpack-react/src/components/Tests/Tests.stories.tsx
+++ b/sandpack-react/src/components/Tests/Tests.stories.tsx
@@ -148,10 +148,10 @@ export const VerboseMode: React.FC = () => {
 };
 
 /**
- * This story is used to test the `hideTestsAndSupressLogs` option.
+ * This story is used to test the `hideTestsAndSupressLogs` prop.
  * Tests content should not be visible in the tests console.
  * It is useful when you want to hide the tests from the user.
- *  
+ *
  */
 export const HiddenTests: React.FC = () => {
   return (
@@ -164,14 +164,13 @@ export const HiddenTests: React.FC = () => {
         "/src/app/sub.test.ts": subTests,
       }}
       options={{
-        hideTestsAndSupressLogs:true,
         visibleFiles: ["/add.ts"],
       }}
       theme={dracula}
     >
-      <SandpackLayout  style={{ "--sp-layout-height": "70vh" } as CSSProperties}>
+      <SandpackLayout style={{ "--sp-layout-height": "70vh" } as CSSProperties}>
         <SandpackCodeEditor showRunButton={false} showLineNumbers />
-        <SandpackTests verbose/>
+        <SandpackTests hideTestsAndSupressLogs />
       </SandpackLayout>
     </SandpackProvider>
   );

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -33,7 +33,6 @@ export const SandpackProvider: React.FC<SandpackProviderProps> = (props) => {
 
         listen: addListener,
         dispatch: dispatchMessage,
-        hideTestsAndSupressLogs: options?.hideTestsAndSupressLogs,
       }}
     >
       <ClasserProvider classes={options?.classes}>

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -33,7 +33,7 @@ export const SandpackProvider: React.FC<SandpackProviderProps> = (props) => {
 
         listen: addListener,
         dispatch: dispatchMessage,
-        testOptions: options?.testOptions,
+        hideTestsAndSupressLogs: options?.hideTestsAndSupressLogs,
       }}
     >
       <ClasserProvider classes={options?.classes}>

--- a/sandpack-react/src/contexts/sandpackContext.tsx
+++ b/sandpack-react/src/contexts/sandpackContext.tsx
@@ -17,7 +17,6 @@ export const SandpackProvider: React.FC<SandpackProviderProps> = (props) => {
   const [clientState, { dispatchMessage, addListener, ...clientOperations }] =
     useClient(props, fileState);
   const appState = useAppState(props, fileState.files);
-
   React.useEffect(() => {
     clientOperations.initializeSandpackIframe();
   }, []);
@@ -34,6 +33,7 @@ export const SandpackProvider: React.FC<SandpackProviderProps> = (props) => {
 
         listen: addListener,
         dispatch: dispatchMessage,
+        testOptions: options?.testOptions,
       }}
     >
       <ClasserProvider classes={options?.classes}>

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -401,12 +401,7 @@ interface SandpackRootProps<
   theme?: SandpackThemeProp;
 }
 
-export interface SandpackTestGlobalOptions {
-  /**
-   * If `hideTestsAndSupressLogs` is true sandpack hides test files and suppresses their output from being logged to the console when a test fails.
-   */
-  hideTestsAndSupressLogs?: boolean;
-}
+ 
 
 export interface SandpackInternalOptions<
   Files extends SandpackFiles | any = any,
@@ -436,10 +431,9 @@ export interface SandpackInternalOptions<
   externalResources?: string[];
   classes?: Record<string, string>;
   /**
-   * Global options for sandpack tests
-   * - hideTestsAndSupressLogs - if true sandpack hides test files and suppresses their output from being logged to the console when a test fails.
+   * If `hideTestsAndSupressLogs` is true sandpack hides test files and suppresses their output from being logged to the console when a test fails.
    */
-  testOptions?: SandpackTestGlobalOptions;
+  hideTestsAndSupressLogs?: boolean;
 }
 
 interface SandpackInternalProps<
@@ -560,11 +554,10 @@ export interface SandpackState {
   resetFile: (path: string) => void;
   resetAllFiles: () => void;
   registerReactDevTools: (value: ReactDevToolsMode) => void;
-  /**
-   * Global options for sandpack tests
-   * - hideTestsAndSupressLogs - if true sandpack hides test files and suppresses their output from being logged to the console when a test fails.
+ /**
+   * If `hideTestsAndSupressLogs` is true sandpack hides test files and suppresses their output from being logged to the console when tests fails. This option will also disables verbose button.
    */
-  testOptions?: SandpackTestGlobalOptions;
+ hideTestsAndSupressLogs?: boolean;
   /**
    * Element refs
    * Different components inside the SandpackProvider might register certain elements of interest for sandpack

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -401,8 +401,6 @@ interface SandpackRootProps<
   theme?: SandpackThemeProp;
 }
 
- 
-
 export interface SandpackInternalOptions<
   Files extends SandpackFiles | any = any,
   TemplateName extends SandpackPredefinedTemplate = SandpackPredefinedTemplate
@@ -430,10 +428,6 @@ export interface SandpackInternalOptions<
   fileResolver?: FileResolver;
   externalResources?: string[];
   classes?: Record<string, string>;
-  /**
-   * If `hideTestsAndSupressLogs` is true sandpack hides test files and suppresses their output from being logged to the console when a test fails.
-   */
-  hideTestsAndSupressLogs?: boolean;
 }
 
 interface SandpackInternalProps<
@@ -554,10 +548,6 @@ export interface SandpackState {
   resetFile: (path: string) => void;
   resetAllFiles: () => void;
   registerReactDevTools: (value: ReactDevToolsMode) => void;
- /**
-   * If `hideTestsAndSupressLogs` is true sandpack hides test files and suppresses their output from being logged to the console when tests fails. This option will also disables verbose button.
-   */
- hideTestsAndSupressLogs?: boolean;
   /**
    * Element refs
    * Different components inside the SandpackProvider might register certain elements of interest for sandpack

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -107,7 +107,6 @@ export interface SandpackOptions {
   wrapContent?: boolean;
   resizablePanels?: boolean;
   codeEditor?: SandpackCodeOptions;
-
   /**
    * This disables editing of content by the user in all files.
    */
@@ -402,6 +401,13 @@ interface SandpackRootProps<
   theme?: SandpackThemeProp;
 }
 
+export interface SandpackTestGlobalOptions {
+  /**
+   * If `hideTestsAndSupressLogs` is true sandpack hides test files and suppresses their output from being logged to the console when a test fails.
+   */
+  hideTestsAndSupressLogs?: boolean;
+}
+
 export interface SandpackInternalOptions<
   Files extends SandpackFiles | any = any,
   TemplateName extends SandpackPredefinedTemplate = SandpackPredefinedTemplate
@@ -429,6 +435,11 @@ export interface SandpackInternalOptions<
   fileResolver?: FileResolver;
   externalResources?: string[];
   classes?: Record<string, string>;
+  /**
+   * Global options for sandpack tests
+   * - hideTestsAndSupressLogs - if true sandpack hides test files and suppresses their output from being logged to the console when a test fails.
+   */
+  testOptions?: SandpackTestGlobalOptions;
 }
 
 interface SandpackInternalProps<
@@ -549,7 +560,11 @@ export interface SandpackState {
   resetFile: (path: string) => void;
   resetAllFiles: () => void;
   registerReactDevTools: (value: ReactDevToolsMode) => void;
-
+  /**
+   * Global options for sandpack tests
+   * - hideTestsAndSupressLogs - if true sandpack hides test files and suppresses their output from being logged to the console when a test fails.
+   */
+  testOptions?: SandpackTestGlobalOptions;
   /**
    * Element refs
    * Different components inside the SandpackProvider might register certain elements of interest for sandpack

--- a/website/docs/src/pages/advanced-usage/components.mdx
+++ b/website/docs/src/pages/advanced-usage/components.mdx
@@ -504,6 +504,40 @@ export default () => (
 `}
 </CodeBlock>
 
+
+### Hiding Tests
+
+You can hide the test files with `visibleFiles` prop.
+Additionally if you want to supress test content and only show the test results, you can use `hideTestsAndSupressLogs` option.
+This option will hide the test files and supress the console logs. And it will disable the verbose button.
+
+<CodeBlock stack>
+{`import { 
+  SandpackProvider, 
+  SandpackLayout, 
+  SandpackCodeEditor, 
+  SandpackTests 
+} from "@codesandbox/sandpack-react";
+
+ 
+
+export default () => (
+  <SandpackProvider
+    template="test-ts"
+    options={{
+      hideTestsAndSupressLogs:true,
+       visibleFiles: ["/add.ts"],
+    }}
+  >
+    <SandpackLayout>
+      <SandpackCodeEditor />
+      <SandpackTests />
+    </SandpackLayout>
+  </SandpackProvider>
+);
+`}
+</CodeBlock>
+
 ## Console
 
 `SandpackConsole` is a Sandpack devtool that allows printing the console logs from a Sandpack client. It is designed to be a light version of a browser console, which means that it's limited to a set of common use cases you may encounter when coding.

--- a/website/docs/src/pages/advanced-usage/components.mdx
+++ b/website/docs/src/pages/advanced-usage/components.mdx
@@ -1,6 +1,7 @@
 import { Callout } from "nextra-theme-docs";
 
 import { CodeBlock } from "../../components/CodeBlock";
+
 import SandpackDecorators from "../../components/Decorators";
 
 # Components
@@ -100,18 +101,11 @@ export default () => (
 </CodeBlock>
 
 <details>
-  
-  <summary>Options</summary>
-  
-| Prop | Type | Default |
-| :- | :- | :- |
-| `showNavigator` | `boolean` | `false`|
-| `showOpenInCodeSandbox`| `boolean` | `true` |
-| `showRefreshButton`| `boolean` | `true` |
-| `showSandpackErrorOverlay`| `boolean` | `true` |
-| `showOpenNewtab` | `boolean` | `true` |
-| `actionsChildren` | JSX.Element | `null` | 
-  
+  <summary>Options</summary>| Prop | Type | Default | | :- | :- | :- | |
+  `showNavigator` | `boolean` | `false`| | `showOpenInCodeSandbox`| `boolean` |
+  `true` | | `showRefreshButton`| `boolean` | `true` | |
+  `showSandpackErrorOverlay`| `boolean` | `true` | | `showOpenNewtab` |
+  `boolean` | `true` | | `actionsChildren` | JSX.Element | `null` |
 </details>
 
 ### Additional buttons
@@ -217,21 +211,21 @@ export default () => (
 <details>
   <summary>Options</summary>
 
-| Prop | Description      | Type  | Default     |
-| :- | :- | :- | :- |
-| `showTabs`            | | `boolean` | `false` |
-| `showLineNumbers`     | | `boolean` | `false` |
-| `showInlineErrors`    | | `boolean` | `false` |
-| `showRunButton`       | | `boolean` | `false` |
-| `wrapContent`         | | `boolean` | `false` |
-| `closableTabs`        | | `boolean` | `false` |
+| Prop                  | Description                                                                                                                                                                                                                                                | Type                                      | Default     |
+| :-------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------- | :---------- |
+| `showTabs`            |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
+| `showLineNumbers`     |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
+| `showInlineErrors`    |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
+| `showRunButton`       |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
+| `wrapContent`         |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
+| `closableTabs`        |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
 | `initMode`            | This provides a way to control how some components are going to be initialized on the page. The CodeEditor and the Preview components are quite expensive and might overload the memory usage, so this gives a certain control of when to initialize them. | `"immediate" \| "lazy" \| "user-visible"` | `"lazy"`    |
-| `extensions`          | CodeMirror extensions for the editor state, which can provide extra features and functionalities to the editor component.    | `Extension[]`           | `undefined` |
-| `extensionsKeymap`    | Property to register CodeMirror extension keymap.    | `KeyBinding[]`          | `undefined  |
-| `id`| By default, Sandpack generates a random value to use as an id. Use this to override this value if you need predictable values.                 | `string`                | `undefined` |
-| `readOnly`            | This disables editing of the editor content by the user.               | `boolean`               | `false`     |
-| `showReadOnly`        | Controls the visibility of Read-only label, which will only appears when `readOnly` is `true`              | `boolean`               | `true`      |
-| `additionalLanguages` | Provides a way to add custom language modes by supplying a language type, applicable file extensions, and a LanguageSupport instance for that syntax mode        | `CustomLanguage[]`      | `undefined` |
+| `extensions`          | CodeMirror extensions for the editor state, which can provide extra features and functionalities to the editor component.                                                                                                                                  | `Extension[]`                             | `undefined` |
+| `extensionsKeymap`    | Property to register CodeMirror extension keymap.                                                                                                                                                                                                          | `KeyBinding[]`                            | `undefined  |
+| `id`                  | By default, Sandpack generates a random value to use as an id. Use this to override this value if you need predictable values.                                                                                                                             | `string`                                  | `undefined` |
+| `readOnly`            | This disables editing of the editor content by the user.                                                                                                                                                                                                   | `boolean`                                 | `false`     |
+| `showReadOnly`        | Controls the visibility of Read-only label, which will only appears when `readOnly` is `true`                                                                                                                                                              | `boolean`                                 | `true`      |
+| `additionalLanguages` | Provides a way to add custom language modes by supplying a language type, applicable file extensions, and a LanguageSupport instance for that syntax mode                                                                                                  | `CustomLanguage[]`                        | `undefined` |
 
 </details>
 
@@ -368,7 +362,7 @@ This is especially useful to get the cursor's current position, add custom decor
 
 ## File Explorer
 
-The `SandpackFileExplorer` provides a minimal but very powerful experience to navigate through files. You can open and close folders,  and open new files.
+The `SandpackFileExplorer` provides a minimal but very powerful experience to navigate through files. You can open and close folders, and open new files.
 
 <CodeBlock stack>
 {`import { 
@@ -388,7 +382,6 @@ export default () => (
 );
 `}
 </CodeBlock>
-
 
 <details>
   <summary>Options</summary>
@@ -452,8 +445,8 @@ export default () => (
 <details>
   <summary>Options</summary>
 
-| Prop | Description      | Type  | Default     |
-| `verbose` | Display individual test results with the test suite hierarchy. | `boolean` | `false`| 
+| Prop | Description | Type | Default |
+| `verbose` | Display individual test results with the test suite hierarchy. | `boolean` | `false`|
 | `watchMode` | Watch files for changes and rerun all tests. Note if changing a test file then the current file will run on it's own | `boolean` | `true` |
 | `onComplete` | A callback that is invoked with the completed specs. | Function | `undefined` |
 
@@ -477,15 +470,15 @@ Add the matchers either as a dependency or as a file and then import the matcher
   SandpackTests 
 } from "@codesandbox/sandpack-react";
 
-const extendedTest = \`import * as matchers from 'jest-extended';
+const extendedTest = \`import \* as matchers from 'jest-extended';
 import { add } from './add';
 
 expect.extend(matchers);
 
 describe('jest-extended matchers are supported', () => {
-  test('adding two positive integers yields a positive integer', () => {
-    expect(add(1, 2)).toBePositive();
-  });
+test('adding two positive integers yields a positive integer', () => {
+expect(add(1, 2)).toBePositive();
+});
 });
 \`;
 
@@ -504,34 +497,30 @@ export default () => (
 `}
 </CodeBlock>
 
-
 ### Hiding Tests
 
-You can hide the test files with `visibleFiles` prop.
-Additionally if you want to supress test content and only show the test results, you can use `hideTestsAndSupressLogs` option.
-This option will hide the test files and supress the console logs. And it will disable the verbose button.
+You can hide the test files using the `visibleFiles` prop. Additionally, if you want to suppress test content and only show the test results, you can use the `hideTestsAndSuppressLogs` option.
+This option will hide the test files, suppress the console logs, and disable the verbose button.
 
 <CodeBlock stack>
-{`import { 
-  SandpackProvider, 
-  SandpackLayout, 
-  SandpackCodeEditor, 
-  SandpackTests 
+  {`
+import {
+  SandpackProvider,
+  SandpackLayout,
+  SandpackCodeEditor,
+  SandpackTests,
 } from "@codesandbox/sandpack-react";
-
- 
 
 export default () => (
   <SandpackProvider
     template="test-ts"
     options={{
-      hideTestsAndSupressLogs:true,
-       visibleFiles: ["/add.ts"],
+      visibleFiles: ["/add.ts"],
     }}
   >
     <SandpackLayout>
       <SandpackCodeEditor />
-      <SandpackTests />
+      <SandpackTests hideTestsAndSupressLogs />
     </SandpackLayout>
   </SandpackProvider>
 );
@@ -552,8 +541,6 @@ There are three ways to print the logs:
 - `<SandpackConsole />`: standalone component to render the logs;
 - `useSandpackConsole`: React hook to consume the console logs from a Sandpack client;
 
-
-
 <CodeBlock stack>
 {`import { Sandpack } from "@codesandbox/sandpack-react";
 
@@ -571,15 +558,15 @@ export default () => (
 <details>
   <summary>`SandpackConsole` Options</summary>
 
-| Prop | Type  | Default | Description | 
-| :- | :- | :- | :- |
-| `clientId` | `string` | `undefined` | |
-| `showHeader` | `boolean` | `true` | |
-| `showSyntaxError` | `boolean` | `false` | |
-| `maxMessageCount` | `number` | `800` | |
-| `onLogsChange` | `(logs: SandpackConsoleData) => void` | | |
-| `resetOnPreviewRestart` | `boolean` | `false` | Reset the console list on every preview restart |
-| `ref` | `SandpackConsoleRef` | `SandpackConsoleRef` | Make possible to imperatively interact with the console component |
+| Prop                    | Type                                  | Default              | Description                                                       |
+| :---------------------- | :------------------------------------ | :------------------- | :---------------------------------------------------------------- |
+| `clientId`              | `string`                              | `undefined`          |                                                                   |
+| `showHeader`            | `boolean`                             | `true`               |                                                                   |
+| `showSyntaxError`       | `boolean`                             | `false`              |                                                                   |
+| `maxMessageCount`       | `number`                              | `800`                |                                                                   |
+| `onLogsChange`          | `(logs: SandpackConsoleData) => void` |                      |                                                                   |
+| `resetOnPreviewRestart` | `boolean`                             | `false`              | Reset the console list on every preview restart                   |
+| `ref`                   | `SandpackConsoleRef`                  | `SandpackConsoleRef` | Make possible to imperatively interact with the console component |
 
 </details>
 
@@ -620,14 +607,14 @@ export default () => (
 <details>
   <summary>Options</summary>
 
-| Prop | Description | Type  | Default |
-| :- | :- | :- | :- |
-| `showTabs`            | | `boolean` | `false` |
-| `showLineNumbers`     | | `boolean` | `false` |
-| `decorators` | Provides a way to draw or style a piece of the content. | `Decorators` | `undefined` |
-| `code` | | `string` | `undefined` |
-| `wrapContent`         | | `boolean` | `false` |
-| `initMode`            | This provides a way to control how some components are going to be initialized on the page. The CodeEditor and the Preview components are quite expensive and might overload the memory usage, so this gives a certain control of when to initialize them. | `"immediate" \| "lazy" \| "user-visible"` | `"lazy"`    |
+| Prop              | Description                                                                                                                                                                                                                                                | Type                                      | Default     |
+| :---------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------- | :---------- |
+| `showTabs`        |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
+| `showLineNumbers` |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
+| `decorators`      | Provides a way to draw or style a piece of the content.                                                                                                                                                                                                    | `Decorators`                              | `undefined` |
+| `code`            |                                                                                                                                                                                                                                                            | `string`                                  | `undefined` |
+| `wrapContent`     |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
+| `initMode`        | This provides a way to control how some components are going to be initialized on the page. The CodeEditor and the Preview components are quite expensive and might overload the memory usage, so this gives a certain control of when to initialize them. | `"immediate" \| "lazy" \| "user-visible"` | `"lazy"`    |
 
 </details>
 
@@ -668,7 +655,6 @@ export default () => (
 `}
 </CodeBlock>
 
-
 The `UnstyledOpenInCodeSandboxButton` is a basic component that does not carry any styles. If you want a ready-to-use component, use the `OpenInCodeSandboxButton` instead, which has the same functionality but includes the CodeSandbox logo.
 
 ## Other components
@@ -704,6 +690,9 @@ Some of the components have configuration props that toggle subparts on/off or t
 of them comunicate with sandpack through the shared context.
 
 <Callout icon="🎉">
-**Congrats!**<br/>
-You can now easily create a custom Sandpack component by reusing some of the building components of the library. The next step is to build your own sandpack components with the help of our custom hooks.
+  **Congrats!**
+  <br />
+  You can now easily create a custom Sandpack component by reusing some of the
+  building components of the library. The next step is to build your own
+  sandpack components with the help of our custom hooks.
 </Callout>

--- a/website/docs/src/pages/advanced-usage/components.mdx
+++ b/website/docs/src/pages/advanced-usage/components.mdx
@@ -101,11 +101,15 @@ export default () => (
 </CodeBlock>
 
 <details>
-  <summary>Options</summary>| Prop | Type | Default | | :- | :- | :- | |
-  `showNavigator` | `boolean` | `false`| | `showOpenInCodeSandbox`| `boolean` |
-  `true` | | `showRefreshButton`| `boolean` | `true` | |
-  `showSandpackErrorOverlay`| `boolean` | `true` | | `showOpenNewtab` |
-  `boolean` | `true` | | `actionsChildren` | JSX.Element | `null` |
+  <summary>Options</summary>
+  |Prop | Type | Default | 
+  |:- | :- | :- | 
+  |`showNavigator` | `boolean` | `false`| 
+  |`showOpenInCodeSandbox`| `boolean` |`true`| 
+  |`showRefreshButton`| `boolean` | `true`|
+  |`showSandpackErrorOverlay`| `boolean` | `true`|
+  |`showOpenNewtab` |`boolean` | `true` |
+  |`actionsChildren` | JSX.Element | `null`|
 </details>
 
 ### Additional buttons

--- a/website/docs/src/pages/advanced-usage/components.mdx
+++ b/website/docs/src/pages/advanced-usage/components.mdx
@@ -1,7 +1,6 @@
 import { Callout } from "nextra-theme-docs";
 
 import { CodeBlock } from "../../components/CodeBlock";
-
 import SandpackDecorators from "../../components/Decorators";
 
 # Components
@@ -101,9 +100,9 @@ export default () => (
 </CodeBlock>
 
 <details>
-
+  
   <summary>Options</summary>
-
+  
 | Prop | Type | Default |
 | :- | :- | :- |
 | `showNavigator` | `boolean` | `false`|
@@ -112,7 +111,7 @@ export default () => (
 | `showSandpackErrorOverlay`| `boolean` | `true` |
 | `showOpenNewtab` | `boolean` | `true` |
 | `actionsChildren` | JSX.Element | `null` | 
-
+  
 </details>
 
 ### Additional buttons
@@ -218,21 +217,21 @@ export default () => (
 <details>
   <summary>Options</summary>
 
-| Prop                  | Description                                                                                                                                                                                                                                                | Type                                      | Default     |
-| :-------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------- | :---------- |
-| `showTabs`            |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
-| `showLineNumbers`     |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
-| `showInlineErrors`    |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
-| `showRunButton`       |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
-| `wrapContent`         |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
-| `closableTabs`        |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
+| Prop | Description      | Type  | Default     |
+| :- | :- | :- | :- |
+| `showTabs`            | | `boolean` | `false` |
+| `showLineNumbers`     | | `boolean` | `false` |
+| `showInlineErrors`    | | `boolean` | `false` |
+| `showRunButton`       | | `boolean` | `false` |
+| `wrapContent`         | | `boolean` | `false` |
+| `closableTabs`        | | `boolean` | `false` |
 | `initMode`            | This provides a way to control how some components are going to be initialized on the page. The CodeEditor and the Preview components are quite expensive and might overload the memory usage, so this gives a certain control of when to initialize them. | `"immediate" \| "lazy" \| "user-visible"` | `"lazy"`    |
-| `extensions`          | CodeMirror extensions for the editor state, which can provide extra features and functionalities to the editor component.                                                                                                                                  | `Extension[]`                             | `undefined` |
-| `extensionsKeymap`    | Property to register CodeMirror extension keymap.                                                                                                                                                                                                          | `KeyBinding[]`                            | `undefined  |
-| `id`                  | By default, Sandpack generates a random value to use as an id. Use this to override this value if you need predictable values.                                                                                                                             | `string`                                  | `undefined` |
-| `readOnly`            | This disables editing of the editor content by the user.                                                                                                                                                                                                   | `boolean`                                 | `false`     |
-| `showReadOnly`        | Controls the visibility of Read-only label, which will only appears when `readOnly` is `true`                                                                                                                                                              | `boolean`                                 | `true`      |
-| `additionalLanguages` | Provides a way to add custom language modes by supplying a language type, applicable file extensions, and a LanguageSupport instance for that syntax mode                                                                                                  | `CustomLanguage[]`                        | `undefined` |
+| `extensions`          | CodeMirror extensions for the editor state, which can provide extra features and functionalities to the editor component.    | `Extension[]`           | `undefined` |
+| `extensionsKeymap`    | Property to register CodeMirror extension keymap.    | `KeyBinding[]`          | `undefined  |
+| `id`| By default, Sandpack generates a random value to use as an id. Use this to override this value if you need predictable values.                 | `string`                | `undefined` |
+| `readOnly`            | This disables editing of the editor content by the user.               | `boolean`               | `false`     |
+| `showReadOnly`        | Controls the visibility of Read-only label, which will only appears when `readOnly` is `true`              | `boolean`               | `true`      |
+| `additionalLanguages` | Provides a way to add custom language modes by supplying a language type, applicable file extensions, and a LanguageSupport instance for that syntax mode        | `CustomLanguage[]`      | `undefined` |
 
 </details>
 
@@ -369,7 +368,7 @@ This is especially useful to get the cursor's current position, add custom decor
 
 ## File Explorer
 
-The `SandpackFileExplorer` provides a minimal but very powerful experience to navigate through files. You can open and close folders, and open new files.
+The `SandpackFileExplorer` provides a minimal but very powerful experience to navigate through files. You can open and close folders,  and open new files.
 
 <CodeBlock stack>
 {`import { 
@@ -389,6 +388,7 @@ export default () => (
 );
 `}
 </CodeBlock>
+
 
 <details>
   <summary>Options</summary>
@@ -452,8 +452,8 @@ export default () => (
 <details>
   <summary>Options</summary>
 
-| Prop | Description | Type | Default |
-| `verbose` | Display individual test results with the test suite hierarchy. | `boolean` | `false`|
+| Prop | Description      | Type  | Default     |
+| `verbose` | Display individual test results with the test suite hierarchy. | `boolean` | `false`| 
 | `watchMode` | Watch files for changes and rerun all tests. Note if changing a test file then the current file will run on it's own | `boolean` | `true` |
 | `onComplete` | A callback that is invoked with the completed specs. | Function | `undefined` |
 
@@ -477,15 +477,15 @@ Add the matchers either as a dependency or as a file and then import the matcher
   SandpackTests 
 } from "@codesandbox/sandpack-react";
 
-const extendedTest = \`import \* as matchers from 'jest-extended';
+const extendedTest = \`import * as matchers from 'jest-extended';
 import { add } from './add';
 
 expect.extend(matchers);
 
 describe('jest-extended matchers are supported', () => {
-test('adding two positive integers yields a positive integer', () => {
-expect(add(1, 2)).toBePositive();
-});
+  test('adding two positive integers yields a positive integer', () => {
+    expect(add(1, 2)).toBePositive();
+  });
 });
 \`;
 
@@ -548,6 +548,8 @@ There are three ways to print the logs:
 - `<SandpackConsole />`: standalone component to render the logs;
 - `useSandpackConsole`: React hook to consume the console logs from a Sandpack client;
 
+
+
 <CodeBlock stack>
 {`import { Sandpack } from "@codesandbox/sandpack-react";
 
@@ -565,15 +567,15 @@ export default () => (
 <details>
   <summary>`SandpackConsole` Options</summary>
 
-| Prop                    | Type                                  | Default              | Description                                                       |
-| :---------------------- | :------------------------------------ | :------------------- | :---------------------------------------------------------------- |
-| `clientId`              | `string`                              | `undefined`          |                                                                   |
-| `showHeader`            | `boolean`                             | `true`               |                                                                   |
-| `showSyntaxError`       | `boolean`                             | `false`              |                                                                   |
-| `maxMessageCount`       | `number`                              | `800`                |                                                                   |
-| `onLogsChange`          | `(logs: SandpackConsoleData) => void` |                      |                                                                   |
-| `resetOnPreviewRestart` | `boolean`                             | `false`              | Reset the console list on every preview restart                   |
-| `ref`                   | `SandpackConsoleRef`                  | `SandpackConsoleRef` | Make possible to imperatively interact with the console component |
+| Prop | Type  | Default | Description | 
+| :- | :- | :- | :- |
+| `clientId` | `string` | `undefined` | |
+| `showHeader` | `boolean` | `true` | |
+| `showSyntaxError` | `boolean` | `false` | |
+| `maxMessageCount` | `number` | `800` | |
+| `onLogsChange` | `(logs: SandpackConsoleData) => void` | | |
+| `resetOnPreviewRestart` | `boolean` | `false` | Reset the console list on every preview restart |
+| `ref` | `SandpackConsoleRef` | `SandpackConsoleRef` | Make possible to imperatively interact with the console component |
 
 </details>
 
@@ -614,14 +616,14 @@ export default () => (
 <details>
   <summary>Options</summary>
 
-| Prop              | Description                                                                                                                                                                                                                                                | Type                                      | Default     |
-| :---------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------- | :---------- |
-| `showTabs`        |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
-| `showLineNumbers` |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
-| `decorators`      | Provides a way to draw or style a piece of the content.                                                                                                                                                                                                    | `Decorators`                              | `undefined` |
-| `code`            |                                                                                                                                                                                                                                                            | `string`                                  | `undefined` |
-| `wrapContent`     |                                                                                                                                                                                                                                                            | `boolean`                                 | `false`     |
-| `initMode`        | This provides a way to control how some components are going to be initialized on the page. The CodeEditor and the Preview components are quite expensive and might overload the memory usage, so this gives a certain control of when to initialize them. | `"immediate" \| "lazy" \| "user-visible"` | `"lazy"`    |
+| Prop | Description | Type  | Default |
+| :- | :- | :- | :- |
+| `showTabs`            | | `boolean` | `false` |
+| `showLineNumbers`     | | `boolean` | `false` |
+| `decorators` | Provides a way to draw or style a piece of the content. | `Decorators` | `undefined` |
+| `code` | | `string` | `undefined` |
+| `wrapContent`         | | `boolean` | `false` |
+| `initMode`            | This provides a way to control how some components are going to be initialized on the page. The CodeEditor and the Preview components are quite expensive and might overload the memory usage, so this gives a certain control of when to initialize them. | `"immediate" \| "lazy" \| "user-visible"` | `"lazy"`    |
 
 </details>
 
@@ -662,6 +664,7 @@ export default () => (
 `}
 </CodeBlock>
 
+
 The `UnstyledOpenInCodeSandboxButton` is a basic component that does not carry any styles. If you want a ready-to-use component, use the `OpenInCodeSandboxButton` instead, which has the same functionality but includes the CodeSandbox logo.
 
 ## Other components
@@ -697,9 +700,6 @@ Some of the components have configuration props that toggle subparts on/off or t
 of them comunicate with sandpack through the shared context.
 
 <Callout icon="🎉">
-  **Congrats!**
-  <br />
-  You can now easily create a custom Sandpack component by reusing some of the
-  building components of the library. The next step is to build your own
-  sandpack components with the help of our custom hooks.
+**Congrats!**<br/>
+You can now easily create a custom Sandpack component by reusing some of the building components of the library. The next step is to build your own sandpack components with the help of our custom hooks.
 </Callout>

--- a/website/docs/src/pages/advanced-usage/components.mdx
+++ b/website/docs/src/pages/advanced-usage/components.mdx
@@ -101,15 +101,18 @@ export default () => (
 </CodeBlock>
 
 <details>
+
   <summary>Options</summary>
-  |Prop | Type | Default | 
-  |:- | :- | :- | 
-  |`showNavigator` | `boolean` | `false`| 
-  |`showOpenInCodeSandbox`| `boolean` |`true`| 
-  |`showRefreshButton`| `boolean` | `true`|
-  |`showSandpackErrorOverlay`| `boolean` | `true`|
-  |`showOpenNewtab` |`boolean` | `true` |
-  |`actionsChildren` | JSX.Element | `null`|
+
+| Prop | Type | Default |
+| :- | :- | :- |
+| `showNavigator` | `boolean` | `false`|
+| `showOpenInCodeSandbox`| `boolean` | `true` |
+| `showRefreshButton`| `boolean` | `true` |
+| `showSandpackErrorOverlay`| `boolean` | `true` |
+| `showOpenNewtab` | `boolean` | `true` |
+| `actionsChildren` | JSX.Element | `null` | 
+
 </details>
 
 ### Additional buttons


### PR DESCRIPTION
## What kind of change does this pull request introduce?

This pull request introduces a new feature to `SandpackProvider` options. 

Specifically, it adds the ability to hide test files and suppress their output from being logged to the console when a test fails. 

Additionally, it allows for the hiding of the `verbose` and `watch` buttons from the test console and prevents opening test files with test links from the console.

## What is the current behavior?

Currently, there is no option to hide test files or suppress their output when they fail in the `SandpackProvider` options. And, there is no option to hide the `verbose` or `watch` buttons from the tests console. 

Also when the user clicks on the test file path, even if it is hidden, the editor will open the test file.

## What is the new behavior?

With this feature, a `hideTestsAndSupressLogs` option is added to the `SandpackProvider` options. 

When set to true, **this option hides test files and suppresses their output from being logged to the console when a test fails.** 

Also, it will prevent opening test files in the editor, if the user clicks on the path link on the console.

Additionally, `hideVerboseButton` and `hideWatchButton` options are added to the `SandpackTests` component to allow the hiding of the `verbose` and `watch` buttons from the tests console.

## What steps did you take to test this?

To test this feature, the following steps were taken:

1. Added the `HiddenTests` component to Storybook.
2. Set `hideTestsAndSupressLogs` to true and ran a test that was expected to fail.
3. Confirmed that the test file was hidden and its output was suppressed from the console.
4. Set `hideVerboseButton` and `hideWatchButton` to true and confirmed that the buttons were hidden from the tests console.


## Checklist

- [x]  Documentation;
- [x]  Storybook (if applicable);
- [ ]  Tests;
- [x]  Ready to be merged;

Closes https://github.com/codesandbox/sandpack/issues/768

<!-- Additional comments -->

Thank you for considering this feature. 🤗
I believe it will be useful for the users of `codesandbox/sandpack` who want to hide tests completely.
Please let me know if you would like me to add & change code/docs for this feature 💪🏻