### PR TITLE
fix: add rtl layout option

### DIFF
--- a/sandpack-react/src/presets/Sandpack.stories.tsx
+++ b/sandpack-react/src/presets/Sandpack.stories.tsx
@@ -329,3 +329,16 @@ Write-Output $example`,
     }}
   />
 );
+
+export const RtlLayout: React.FC = () => {
+  return (
+    <>
+      <Sandpack
+        options={{
+          rtl: true,
+        }}
+        template="react"
+      />
+    </>
+  );
+};

--- a/sandpack-react/src/presets/Sandpack.tsx
+++ b/sandpack-react/src/presets/Sandpack.tsx
@@ -35,6 +35,7 @@ export const Sandpack: SandpackInternal = ({
   options.editorWidthPercentage ??= 50;
   options.showConsole ??= false;
 
+  const rtlLayout = options?.rtl ?? false;
   const codeEditorOptions: CodeEditorProps = {
     showTabs: options.showTabs,
     showLineNumbers: options.showLineNumbers,
@@ -143,7 +144,7 @@ export const Sandpack: SandpackInternal = ({
     const boundaries = Math.min(Math.max(offset, 25), 75);
 
     if (isHorizontal) {
-      setHorizontalSize(boundaries);
+      setHorizontalSize(rtlLayout ? 100 - boundaries : boundaries);
     } else {
       setVerticalSize(boundaries);
     }
@@ -196,7 +197,9 @@ export const Sandpack: SandpackInternal = ({
       theme={theme}
       {...props}
     >
-      <SandpackLayout>
+      <SandpackLayout
+        className={rtlLayout ? classNames(rtlLayoutClassName) : ""}
+      >
         <SandpackCodeEditor
           {...codeEditorOptions}
           style={{
@@ -218,7 +221,11 @@ export const Sandpack: SandpackInternal = ({
             onMouseDown={(event): void => {
               dragEventTargetRef.current = event.target;
             }}
-            style={{ left: `calc(${horizontalSize}% - 5px)` }}
+            style={{
+              left: `calc(${
+                rtlLayout ? 100 - horizontalSize : horizontalSize
+              }% - 5px)`,
+            }}
           />
         )}
 
@@ -336,4 +343,13 @@ const buttonCounter = css({
 const consoleWrapper = css({
   width: "100%",
   overflow: "hidden",
+});
+
+const rtlLayoutClassName = css({
+  flexDirection: "row-reverse",
+
+  "@media screen and (max-width: 768px)": {
+    flexFlow: "wrap-reverse !important",
+    flexDirection: "initial",
+  },
 });

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -96,6 +96,11 @@ export interface SandpackOptions {
   editorHeight?: React.CSSProperties["height"];
   classes?: Record<string, string>;
 
+  /**
+   * right to left layout
+   * @default false
+   */
+  rtl?: boolean;
   showNavigator?: boolean;
   showLineNumbers?: boolean;
   showInlineErrors?: boolean;
@@ -438,6 +443,11 @@ interface SandpackInternalProps<
     editorWidthPercentage?: number;
     editorHeight?: React.CSSProperties["height"];
 
+    /**
+     * right to left layout
+     * @default false
+     */
+    rtl?: boolean;
     showNavigator?: boolean;
     showLineNumbers?: boolean;
     showInlineErrors?: boolean;

--- a/website/docs/src/pages/getting-started/layout.mdx
+++ b/website/docs/src/pages/getting-started/layout.mdx
@@ -197,3 +197,19 @@ The `<Sandpack />` preset component has resizable columns and rows by default, a
 ```
 
 Other components (`SandpackProvider` for example) do not have this functionality and it must be implemented by the user.
+
+### Right to left layout
+
+<CodeBlock stack>
+{`import { Sandpack } from "@codesandbox/sandpack-react";
+export default function App() {
+  return (
+    <Sandpack 
+      options={{
+        rtl: true, // default false
+      }}
+    />
+  );
+}
+`}
+</CodeBlock>


### PR DESCRIPTION
## What kind of change does this pull request introduce?

feature: add rtl option (so easy to rtl layout)

- usage

```jsx
export const RtlLayout: React.FC = () => {
  return (
    <>
      <Sandpack
        options={{
          rtl: true,
        }}
        template="react"
      />
    </>
  );
};
```

<img width="797" alt="image" src="https://user-images.githubusercontent.com/12525415/221796917-f1adadfd-7fd4-4756-b460-f9d742c0c7d6.png">

## Checklist

- [x] Documentation;
- [x] Storybook (if applicable);
- [ ] Tests;
- [x] Ready to be merged;

