### PR TITLE
fix: Make generateRandomId actually generate a unique id

### DIFF
--- a/sandpack-react/src/utils/stringUtils.ts
+++ b/sandpack-react/src/utils/stringUtils.ts
@@ -109,5 +109,9 @@ export const isDarkColor = (color: string): boolean => {
   return yiq < 128;
 };
 
-export const generateRandomId = (): string =>
-  Math.floor(Math.random() * 10000).toString();
+// Minimal cuid-like id
+let lastCount = 0;
+export const generateRandomId = (): string => {
+  const random = +(Date.now().toString(10).substr(0, 4) + lastCount++);
+  return random.toString(16);
+};


### PR DESCRIPTION
## What kind of change does this pull request introduce?

<!-- Is it a Bug fix, feature, documentation update... -->

Discovered a small issue with keys when spamming the console with logs

## What is the current behavior?

<!-- You can also link to an open issue here -->

`generateRandomId` is a bit too optimistic on how random Math.random is and is used as a unique value instead of a random value

## What is the new behavior?

`generateRandomId` has a counter to guarantee uniqueness across the entire application
