### PR TITLE
feat: Improved loading and restarts

### DIFF
--- a/sandpack-client/src/clients/node/iframe.utils.ts
+++ b/sandpack-client/src/clients/node/iframe.utils.ts
@@ -13,7 +13,7 @@ export async function loadPreviewIframe(
     "Failed to await preview iframe: no content window found"
   );
 
-  const TIME_OUT = 3_000;
+  const TIME_OUT = 90_000;
   const MAX_MANY_TIRES = 20;
   let tries = 0;
   let timeout: ReturnType<typeof setTimeout>;

--- a/sandpack-client/src/clients/node/types.ts
+++ b/sandpack-client/src/clients/node/types.ts
@@ -66,6 +66,7 @@ export type SandpackNodeMessage = BaseSandpackMessage &
     | SandpackURLsMessages
     | SandpackBundlerMessages
     | SandpackShellMessages
+    | { type: "connected" }
     | {
         type: "stdout";
         payload: SandpackShellStdoutData;

--- a/sandpack-react/src/contexts/utils/useClient.ts
+++ b/sandpack-react/src/contexts/utils/useClient.ts
@@ -311,7 +311,10 @@ export const useClient: UseClient = ({ options, customSetup }, filesState) => {
   const handleMessage = (msg: SandpackMessage): void => {
     if (msg.type === "state") {
       setState((prev) => ({ ...prev, bundlerState: msg.state }));
-    } else if (msg.type === "done" && !msg.compilatonError) {
+    } else if (
+      (msg.type === "done" && !msg.compilatonError) ||
+      msg.type === "connected"
+    ) {
       if (timeoutHook.current) {
         clearTimeout(timeoutHook.current);
       }


### PR DESCRIPTION
## What kind of change does this pull request introduce?

- Improved loading
  - Increase preview timeout to 90secs, matching default http request timeout
  - Add connected event to prevent timing out while downloading node modules or loading preview
- improved restart
  - re-use downloaded modules and caches by reusing the same nodebox instance