### PR TITLE
fix(sandpack-react): tweak imports to avoid circular deps

### DIFF
--- a/sandpack-react/src/components/Console/ConsoleList.tsx
+++ b/sandpack-react/src/components/Console/ConsoleList.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
-import { CodeEditor } from "..";
 import { css, THEME_PREFIX } from "../../styles";
 import { classNames } from "../../utils/classNames";
+import { CodeEditor } from "../CodeEditor";
 
 import { fromConsoleToString } from "./utils/fromConsoleToString";
 import type { SandpackConsoleData } from "./utils/getType";

--- a/sandpack-react/src/components/Console/SandpackConsole.tsx
+++ b/sandpack-react/src/components/Console/SandpackConsole.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useSandpack, useSandpackShell } from "../..";
+import { useSandpack, useSandpackShell } from "../../hooks";
 import { useSandpackShellStdout } from "../../hooks/useSandpackShellStdout";
 import { css, THEME_PREFIX } from "../../styles";
 import { classNames } from "../../utils/classNames";

--- a/sandpack-react/src/components/ReactDevTools/index.tsx
+++ b/sandpack-react/src/components/ReactDevTools/index.tsx
@@ -1,8 +1,7 @@
 import { useClasser } from "@code-hike/classer";
 import * as React from "react";
 
-import { useSandpackTheme } from "../..";
-import { useSandpack } from "../../hooks/useSandpack";
+import { useSandpackTheme, useSandpack } from "../../hooks";
 import { css, THEME_PREFIX } from "../../styles";
 import { classNames } from "../../utils/classNames";
 

--- a/sandpack-react/src/components/common/ErrorOverlay.tsx
+++ b/sandpack-react/src/components/common/ErrorOverlay.tsx
@@ -1,8 +1,7 @@
 import { useClasser } from "@code-hike/classer";
 import * as React from "react";
 
-import { useSandpack, useSandpackShell } from "../..";
-import { useErrorMessage } from "../../hooks/useErrorMessage";
+import { useSandpack, useSandpackShell, useErrorMessage } from "../../hooks";
 import { css, THEME_PREFIX } from "../../styles";
 import {
   absoluteClassName,

--- a/sandpack-react/src/components/common/LoadingOverlay.tsx
+++ b/sandpack-react/src/components/common/LoadingOverlay.tsx
@@ -6,7 +6,7 @@ import {
   useLoadingOverlayState,
   FADE_ANIMATION_DURATION,
 } from "../../hooks/useLoadingOverlayState";
-import { usePreviewProgress } from "../../hooks/usePreviewProgress";
+import { useSandpackPreviewProgress } from "../../hooks/useSandpackPreviewProgress";
 import { useSandpackShellStdout } from "../../hooks/useSandpackShellStdout";
 import { css, THEME_PREFIX } from "../../styles";
 import {
@@ -56,7 +56,7 @@ export const LoadingOverlay = ({
   const [shouldShowStdout, setShouldShowStdout] = React.useState(false);
 
   const loadingOverlayState = useLoadingOverlayState(clientId, loading);
-  const progressMessage = usePreviewProgress();
+  const progressMessage = useSandpackPreviewProgress();
   const { logs: stdoutData } = useSandpackShellStdout({});
 
   React.useEffect(() => {

--- a/sandpack-react/src/components/common/LoadingOverlay.tsx
+++ b/sandpack-react/src/components/common/LoadingOverlay.tsx
@@ -1,7 +1,7 @@
 import { useClasser } from "@code-hike/classer";
 import * as React from "react";
 
-import { useSandpack } from "../..";
+import { useSandpack } from "../../hooks";
 import {
   useLoadingOverlayState,
   FADE_ANIMATION_DURATION,

--- a/sandpack-react/src/hooks/index.ts
+++ b/sandpack-react/src/hooks/index.ts
@@ -7,3 +7,4 @@ export * from "./useSandpackTheme";
 export * from "./useTranspiledCode";
 export * from "./useSandpackClient";
 export * from "./useSandpackShell";
+export * from "./useSandpackPreviewProgress";

--- a/sandpack-react/src/hooks/usePreviewProgress.ts
+++ b/sandpack-react/src/hooks/usePreviewProgress.ts
@@ -1,7 +1,7 @@
 import type { WorkerStatusUpdate } from "@codesandbox/nodebox";
 import * as React from "react";
 
-import { useSandpack } from "..";
+import { useSandpack } from ".";
 
 const mapProgressMessage = (
   originalMessage: WorkerStatusUpdate & { command?: string },

--- a/sandpack-react/src/hooks/useSandpackPreviewProgress.ts
+++ b/sandpack-react/src/hooks/useSandpackPreviewProgress.ts
@@ -24,7 +24,7 @@ const mapProgressMessage = (
   }
 };
 
-export const usePreviewProgress = () => {
+export const useSandpackPreviewProgress = () => {
   const [isReady, setIsReady] = React.useState(false);
   const [totalDependencies, setTotalDependencies] = React.useState<number>();
   const [loadingMessage, setLoadingMessage] = React.useState<null | string>(


### PR DESCRIPTION

reduce the number of circular dependencies

## What is the current behavior?

```
(!) Circular dependencies
src/index.ts -> src/components/index.ts -> src/components/FileExplorer/index.tsx -> src/components/common/index.ts -> src/components/common/ErrorOverlay.tsx -> src/index.ts
src/index.ts -> src/components/index.ts -> src/components/FileExplorer/index.tsx -> src/components/common/index.ts -> src/components/common/LoadingOverlay.tsx -> src/index.ts
src/index.ts -> src/components/index.ts -> src/components/FileExplorer/index.tsx -> src/components/common/index.ts -> src/components/common/LoadingOverlay.tsx -> src/hooks/usePreviewProgress.ts -> src/index.ts
...and 4 more
```

## What is the new behavior?

```
(!) Circular dependency
src/components/FileExplorer/ModuleList.tsx -> src/components/FileExplorer/Directory.tsx -> src/components/FileExplorer/ModuleList.tsx
```

## What steps did you take to test this?

- build the package

