### PR TITLE
docs(showSandpackErrorOverlay): flag is missing docs (#853)

### DIFF
--- a/sandpack-react/src/components/Preview/index.tsx
+++ b/sandpack-react/src/components/Preview/index.tsx
@@ -26,6 +26,11 @@ export interface PreviewProps {
   showOpenInCodeSandbox?: boolean;
   showRefreshButton?: boolean;
   showRestartButton?: boolean;
+
+  /**
+   * Whether to show the `<ErrorOverlay>` component on top of
+   * the preview, if a runtime error happens.
+   */
   showSandpackErrorOverlay?: boolean;
   showOpenNewtab?: boolean;
   actionsChildren?: JSX.Element;

--- a/website/docs/src/pages/advanced-usage/components.mdx
+++ b/website/docs/src/pages/advanced-usage/components.mdx
@@ -106,14 +106,14 @@ export default () => (
   
   <summary>Options</summary>
   
-| Prop | Type | Default |
-| :- | :- | :- |
-| `showNavigator` | `boolean` | `false`|
-| `showOpenInCodeSandbox`| `boolean` | `true` |
-| `showRefreshButton`| `boolean` | `true` |
-| `showSandpackErrorOverlay`| `boolean` | `true` |
-| `showOpenNewtab` | `boolean` | `true` |
-| `actionsChildren` | JSX.Element | `null` | 
+| Prop | Description | Type | Default |
+| :- | :- | :- | :- |
+| `showNavigator` | | `boolean` | `false`|
+| `showOpenInCodeSandbox`| | `boolean` | `true` |
+| `showRefreshButton`| | `boolean` | `true` |
+| `showSandpackErrorOverlay`| Whether to show the `<ErrorOverlay>` component on top of the preview, if a runtime error happens. | `boolean` | `true` |
+| `showOpenNewtab` | | `boolean` | `true` |
+| `actionsChildren` | | JSX.Element | `null` |
   
 </details>
 


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Documentation both in the docs and in the TS definitions.

<!-- Is it a Bug fix, feature, documentation update... -->

## What is the current behavior?

Closes: https://github.com/codesandbox/sandpack/issues/853

## What is the new behavior?
<img width="868" alt="Screenshot 2023-03-22 at 21 34 09" src="https://user-images.githubusercontent.com/11327761/227016980-ac88a0d4-64f4-40b3-b3d4-80a8c97fc112.png">


## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation;
- [ ] Storybook (if applicable);
- [ ] Tests;
- [ ] Ready to be merged;


<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
