### PR TITLE
fix(SandpackConsole): clear logs based on maxMessageCount option

### DIFF
--- a/sandpack-react/src/components/Console/Console.stories.tsx
+++ b/sandpack-react/src/components/Console/Console.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { SandpackCodeEditor, SandpackPreview } from "..";
 import { SandpackProvider, SandpackLayout, Sandpack } from "../..";
@@ -182,3 +182,45 @@ console.log("foo");`,
     </SandpackLayout>
   </SandpackProvider>
 );
+
+export const MaxMessageCount = () => {
+  const [mode, setMode] = useState('client');
+  const [maxMessageCount, setMaxMessageCount] = useState(5);
+
+  return (
+    <>
+      <SandpackProvider
+        key={mode}
+        files={{
+          "/index.js": `new Array(10).fill('').forEach((_, i) => console.log(i));`,
+          "/package.json": JSON.stringify({
+            scripts: { start: "node index.js" },
+          }),
+        }}
+        options={{ visibleFiles: ["/index.js"], recompileDelay: 500 }}
+        template={mode === 'client' ? 'vanilla' : 'node'}
+      >
+        <SandpackLayout>
+          <SandpackCodeEditor />
+          <SandpackConsole standalone maxMessageCount={Number(maxMessageCount)} />
+        </SandpackLayout>
+        <div style={{
+          marginTop: 32,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+          justifyItems: 'left',
+          width: 'fit-content'
+        }}>
+          <button onClick={() => setMode(mode === 'client' ? 'server' : 'client')}>
+            Toggle mode: {mode}
+          </button>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <span>Max Message Count</span>
+            <input type="number" value={maxMessageCount} onChange={e => setMaxMessageCount(+e.target.value)} />
+          </label>
+        </div>
+      </SandpackProvider>
+    </>
+  );
+}

--- a/sandpack-react/src/components/Console/useSandpackConsole.ts
+++ b/sandpack-react/src/components/Console/useSandpackConsole.ts
@@ -67,7 +67,7 @@ export const useSandpackConsole = ({
             }
           );
 
-          while (messages.length > MAX_MESSAGE_COUNT) {
+          while (messages.length > maxMessageCount) {
             messages.shift();
           }
 

--- a/sandpack-react/src/hooks/useSandpackShellStdout.ts
+++ b/sandpack-react/src/hooks/useSandpackShellStdout.ts
@@ -38,7 +38,7 @@ export const useSandpackShellStdout = ({
             { data: message.payload.data!, id: generateRandomId() },
           ];
 
-          while (messages.length > MAX_MESSAGE_COUNT) {
+          while (messages.length > maxMessageCount) {
             messages.shift();
           }
 


### PR DESCRIPTION
## What kind of change does this pull request introduce?

<!-- Is it a Bug fix, feature, documentation update... -->

This fixes a bug with the `Console` component where the `maxMessageCount` option isn't respected.

## What is the current behavior?

<!-- You can also link to an open issue here -->

The `maxMessageCount` option is ignored and instead the default `MAX_MESSAGE_COUNT` value is used when determining if old logs should be cleaned up.

https://github.com/codesandbox/sandpack/issues/865

## What is the new behavior?

<!-- if this is a feature change -->

The `maxMessageCount` is respected so that logs are cleaned up based on what the user specifies.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Rendered an `Editor` and `Console` component
2. Changed the `maxMessageCount` option
3. Tested with the `vanilla` (client) and `node` (server) templates by logging more lines than the `maxMessageCount` option
4. Verified that the logs earlier in the list were cleaned up

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation; N/A
- [x] Storybook (if applicable);
- [ ] Tests; N/A
- [x] Ready to be merged;


<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
