### PR TITLE
feat(Preview): add startRoute prop to override Provider default

### DIFF
--- a/sandpack-client/src/clients/node/client.utils.ts
+++ b/sandpack-client/src/clients/node/client.utils.ts
@@ -6,6 +6,15 @@ import { invariant } from "outvariant";
 import type { SandpackBundlerFiles } from "../..";
 import { createError } from "../..";
 
+let counter = 0;
+
+export function generateRandomId() {
+  const now = Date.now();
+  const randomNumber = Math.round(Math.random() * 10000);
+  const count = (counter += 1);
+  return (+`${now}${randomNumber}${count}`).toString(16);
+}
+
 export const writeBuffer = (
   content: string | Uint8Array,
   encoding: BufferEncoding = "utf8"

--- a/sandpack-client/src/clients/node/index.ts
+++ b/sandpack-client/src/clients/node/index.ts
@@ -178,7 +178,7 @@ export class SandpackNode extends SandpackClient {
 
     const { url } = await this.emulator.preview.getByShellId(id);
 
-    this.iframePreviewUrl = url + this.options.startRoute ?? "";
+    this.iframePreviewUrl = url + this.options.startRoute;
   }
 
   /**

--- a/sandpack-client/src/clients/node/index.ts
+++ b/sandpack-client/src/clients/node/index.ts
@@ -178,7 +178,7 @@ export class SandpackNode extends SandpackClient {
 
     const { url } = await this.emulator.preview.getByShellId(id);
 
-    this.iframePreviewUrl = url + this.options.startRoute;
+    this.iframePreviewUrl = url + this.options.startRoute ?? "";
   }
 
   /**

--- a/sandpack-client/src/clients/node/inject-scripts/consoleHook.ts
+++ b/sandpack-client/src/clients/node/inject-scripts/consoleHook.ts
@@ -2,6 +2,10 @@
 import Hook from "console-feed/lib/Hook";
 import { Encode } from "console-feed/lib/Transform";
 
+declare global {
+  const scope: { channelId: string };
+}
+
 Hook(window.console, (log) => {
   const encodeMessage = Encode(log) as any;
   parent.postMessage(
@@ -9,6 +13,7 @@ Hook(window.console, (log) => {
       type: "console",
       codesandbox: true,
       log: Array.isArray(encodeMessage) ? encodeMessage[0] : encodeMessage,
+      channelId: scope.channelId,
     },
     "*"
   );

--- a/sandpack-client/src/clients/node/inject-scripts/historyListener.ts
+++ b/sandpack-client/src/clients/node/inject-scripts/historyListener.ts
@@ -1,6 +1,8 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/explicit-function-return-type, no-restricted-globals */
+/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/explicit-function-return-type, no-restricted-globals, @typescript-eslint/no-explicit-any  */
 
-export function setupHistoryListeners() {
+export function setupHistoryListeners({ scope }: { scope: any }) {
+  const channelId = scope?.channelId;
+
   // @ts-ignore
   const origHistoryProto = window.history.__proto__;
 
@@ -14,6 +16,7 @@ export function setupHistoryListeners() {
         url,
         back: historyPosition > 0,
         forward: historyPosition < historyList.length - 1,
+        channelId,
       },
       "*"
     );

--- a/sandpack-client/src/clients/node/inject-scripts/historyListener.ts
+++ b/sandpack-client/src/clients/node/inject-scripts/historyListener.ts
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/explicit-function-return-type, no-restricted-globals, @typescript-eslint/no-explicit-any  */
 
-export function setupHistoryListeners({ scope }: { scope: any }) {
-  const channelId = scope?.channelId;
-
+export function setupHistoryListeners({
+  scope,
+}: {
+  scope: { channelId: string };
+}) {
   // @ts-ignore
   const origHistoryProto = window.history.__proto__;
 
@@ -16,7 +18,7 @@ export function setupHistoryListeners({ scope }: { scope: any }) {
         url,
         back: historyPosition > 0,
         forward: historyPosition < historyList.length - 1,
-        channelId,
+        channelId: scope.channelId,
       },
       "*"
     );

--- a/sandpack-client/src/clients/node/inject-scripts/index.ts
+++ b/sandpack-client/src/clients/node/inject-scripts/index.ts
@@ -11,18 +11,21 @@ import { setupHistoryListeners } from "./historyListener";
 const scripts = [
   { code: setupHistoryListeners.toString(), id: "historyListener" },
   {
-    code: "function consoleHook() {" + consoleHook + "\n};",
+    code: "function consoleHook({ scope }) {" + consoleHook + "\n};",
     id: "consoleHook",
   },
 ];
 
-export const injectScriptToIframe = (iframe: HTMLIFrameElement): void => {
+export const injectScriptToIframe = (
+  iframe: HTMLIFrameElement,
+  channelId: string
+): void => {
   scripts.forEach(({ code, id }) => {
     const message: InjectMessage = {
       uid: id,
       type: INJECT_MESSAGE_TYPE,
       code: `exports.activate = ${code}`,
-      scope: {},
+      scope: { channelId },
     };
 
     iframe.contentWindow?.postMessage(message, "*");

--- a/sandpack-react/src/components/Console/SandpackConsole.tsx
+++ b/sandpack-react/src/components/Console/SandpackConsole.tsx
@@ -192,7 +192,7 @@ export const SandpackConsole = React.forwardRef<
 
         {standalone && (
           <>
-            <DependenciesProgress />
+            <DependenciesProgress clientId={clientId} />
             <iframe ref={iframe} />
           </>
         )}

--- a/sandpack-react/src/components/Navigator/index.tsx
+++ b/sandpack-react/src/components/Navigator/index.tsx
@@ -48,19 +48,21 @@ const inputClassName = css({
 export interface NavigatorProps {
   clientId: string;
   onURLChange?: (newURL: string) => void;
+  startRoute?: string;
 }
 
 export const Navigator = ({
   clientId,
   onURLChange,
   className,
+  startRoute,
   ...props
 }: NavigatorProps & React.HTMLAttributes<HTMLDivElement>): JSX.Element => {
   const [baseUrl, setBaseUrl] = React.useState<string>("");
   const { sandpack, dispatch, listen } = useSandpack();
 
   const [relativeUrl, setRelativeUrl] = React.useState<string>(
-    sandpack.startRoute ?? "/"
+    startRoute ?? sandpack.startRoute ?? "/"
   );
 
   const [backEnabled, setBackEnabled] = React.useState(false);

--- a/sandpack-react/src/components/Preview/Preview.stories.tsx
+++ b/sandpack-react/src/components/Preview/Preview.stories.tsx
@@ -55,22 +55,6 @@ export const Viewport: Story<PreviewProps> = (args) => (
   </SandpackProvider>
 );
 
-Viewport.argTypes = {
-  viewportSize: {
-    control: {
-      type: "select",
-      options: [
-        "iPhone X",
-        "iPad",
-        "Pixel 2",
-        "Moto G4",
-        "Surface Duo",
-        "auto",
-      ],
-    },
-  },
-};
-
 export const WithNavigator: React.FC = () => (
   <SandpackProvider
     files={{
@@ -85,39 +69,20 @@ export const WithNavigator: React.FC = () => (
 );
 
 export const MultipleRoutePreviews: React.FC = () => {
-  const multiRoutePreviewCode = `
-    import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-
-    const router = createBrowserRouter([
-      { path: "/about", element: <div>About!</div> },
-      { path: "/careers", element: <div>Careers!</div> },
-    ]);
-
-    export default function MultiRoutePreviews() {
-      return <RouterProvider router={router} />;
-    }
-  `;
-
   return (
     <SandpackProvider
-      options={{ startRoute: "default" }}
       files={{
-        "/App.js": multiRoutePreviewCode,
-        "package.json": JSON.stringify({
-          dependencies: {
-            react: "^18.0.0",
-            "react-dom": "^18.0.0",
-            "react-scripts": "^4.0.0",
-            "react-router-dom": "^6.10.0",
-          },
-          main: "/index.js",
-        }),
+        "/pages/index.js": `export default () => "Home"`,
+        "/pages/about.js": `export default () => "About"`,
+        "/pages/careers.js": `export default () => "Careers"`,
       }}
-      template="react"
+      options={{ startRoute: "/" }}
+      template="nextjs"
     >
       <SandpackLayout>
-        <SandpackPreview showNavigator startRoute="/about" />
-        <SandpackPreview showNavigator startRoute="/careers" />
+        <SandpackPreview showNavigator />
+        <SandpackPreview startRoute="/about" showNavigator />
+        <SandpackPreview startRoute="/careers" showNavigator />
       </SandpackLayout>
     </SandpackProvider>
   );

--- a/sandpack-react/src/components/Preview/Preview.stories.tsx
+++ b/sandpack-react/src/components/Preview/Preview.stories.tsx
@@ -84,6 +84,45 @@ export const WithNavigator: React.FC = () => (
   </SandpackProvider>
 );
 
+export const MultipleRoutePreviews: React.FC = () => {
+  const multiRoutePreviewCode = `
+    import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+
+    const router = createBrowserRouter([
+      { path: "/about", element: <div>About!</div> },
+      { path: "/careers", element: <div>Careers!</div> },
+    ]);
+
+    export default function MultiRoutePreviews() {
+      return <RouterProvider router={router} />;
+    }
+  `;
+
+  return (
+    <SandpackProvider
+      options={{ startRoute: "default" }}
+      files={{
+        "/App.js": multiRoutePreviewCode,
+        "package.json": JSON.stringify({
+          dependencies: {
+            react: "^18.0.0",
+            "react-dom": "^18.0.0",
+            "react-scripts": "^4.0.0",
+            "react-router-dom": "^6.10.0",
+          },
+          main: "/index.js",
+        }),
+      }}
+      template="react"
+    >
+      <SandpackLayout>
+        <SandpackPreview showNavigator startRoute="/about" />
+        <SandpackPreview showNavigator startRoute="/careers" />
+      </SandpackLayout>
+    </SandpackProvider>
+  );
+};
+
 export const AutoResize: React.FC = () => (
   <SandpackProvider
     files={{

--- a/sandpack-react/src/components/Preview/index.tsx
+++ b/sandpack-react/src/components/Preview/index.tsx
@@ -35,6 +35,7 @@ export interface PreviewProps {
   showOpenNewtab?: boolean;
   actionsChildren?: JSX.Element;
   children?: JSX.Element;
+  startRoute?: string;
 }
 
 const previewClassName = css({
@@ -104,12 +105,14 @@ export const SandpackPreview = React.forwardRef<
       actionsChildren = <></>,
       children,
       className,
+      startRoute,
       ...props
     },
     ref
   ) => {
-    const { sandpack, listen, iframe, getClient, clientId } =
-      useSandpackClient();
+    const { sandpack, listen, iframe, getClient, clientId } = useSandpackClient(
+      { startRoute }
+    );
     const [iframeComputedHeight, setComputedAutoHeight] = React.useState<
       number | null
     >(null);
@@ -158,7 +161,11 @@ export const SandpackPreview = React.forwardRef<
         {...props}
       >
         {showNavigator && (
-          <Navigator clientId={clientId} onURLChange={handleNewURL} />
+          <Navigator
+            clientId={clientId}
+            onURLChange={handleNewURL}
+            startRoute={startRoute}
+          />
         )}
 
         <div className={classNames(c("preview-container"), previewClassName)}>

--- a/sandpack-react/src/components/Preview/index.tsx
+++ b/sandpack-react/src/components/Preview/index.tsx
@@ -105,7 +105,7 @@ export const SandpackPreview = React.forwardRef<
       actionsChildren = <></>,
       children,
       className,
-      startRoute,
+      startRoute = "/",
       ...props
     },
     ref

--- a/sandpack-react/src/components/common/DependenciesProgress.tsx
+++ b/sandpack-react/src/components/common/DependenciesProgress.tsx
@@ -2,8 +2,13 @@ import { useSandpackPreviewProgress } from "../..";
 import { css } from "../../styles";
 import { fadeIn } from "../../styles/shared";
 
-export const DependenciesProgress: React.FC = () => {
-  const progressMessage = useSandpackPreviewProgress(3_000);
+export const DependenciesProgress: React.FC<{ clientId?: string }> = ({
+  clientId,
+}) => {
+  const progressMessage = useSandpackPreviewProgress({
+    timeout: 3_000,
+    clientId,
+  });
 
   if (!progressMessage) {
     return null;

--- a/sandpack-react/src/components/common/LoadingOverlay.tsx
+++ b/sandpack-react/src/components/common/LoadingOverlay.tsx
@@ -56,8 +56,8 @@ export const LoadingOverlay = ({
   const [shouldShowStdout, setShouldShowStdout] = React.useState(false);
 
   const loadingOverlayState = useLoadingOverlayState(clientId, loading);
-  const progressMessage = useSandpackPreviewProgress();
-  const { logs: stdoutData } = useSandpackShellStdout({});
+  const progressMessage = useSandpackPreviewProgress({ clientId });
+  const { logs: stdoutData } = useSandpackShellStdout({ clientId });
 
   React.useEffect(() => {
     let timer: NodeJS.Timer;

--- a/sandpack-react/src/contexts/utils/useClient.ts
+++ b/sandpack-react/src/contexts/utils/useClient.ts
@@ -34,6 +34,8 @@ interface SandpackConfigState {
   status: SandpackStatus;
 }
 
+export type ClientPropsOverride = { startRoute?: string };
+
 export interface UseClientOperations {
   clients: Record<string, SandpackClientType>;
   initializeSandpackIframe: () => void;
@@ -41,7 +43,8 @@ export interface UseClientOperations {
   unregisterBundler: (clientId: string) => void;
   registerBundler: (
     iframe: HTMLIFrameElement,
-    clientId: string
+    clientId: string,
+    clientPropsOverride?: ClientPropsOverride
   ) => Promise<void>;
   registerReactDevTools: (value: ReactDevToolsMode) => void;
   addListener: (
@@ -85,7 +88,12 @@ export const useClient: UseClient = ({ options, customSetup }, filesState) => {
    */
   const intersectionObserver = useRef<IntersectionObserver | null>(null);
   const lazyAnchorRef = useRef<HTMLDivElement>(null);
-  const preregisteredIframes = useRef<Record<string, HTMLIFrameElement>>({});
+  const preregisteredIframes = useRef<
+    Record<
+      string,
+      { iframe: HTMLIFrameElement; clientPropsOverride?: ClientPropsOverride }
+    >
+  >({});
   const clients = useRef<Record<string, SandpackClientType>>({});
   const timeoutHook = useRef<NodeJS.Timer | null>(null);
   const unsubscribeClientListeners = useRef<
@@ -106,7 +114,8 @@ export const useClient: UseClient = ({ options, customSetup }, filesState) => {
   const createClient = useCallback(
     async (
       iframe: HTMLIFrameElement,
-      clientId: string
+      clientId: string,
+      clientPropsOverride?: ClientPropsOverride
     ): Promise<SandpackClientType> => {
       options ??= {};
       customSetup ??= {};
@@ -131,7 +140,7 @@ export const useClient: UseClient = ({ options, customSetup }, filesState) => {
         {
           externalResources: options.externalResources,
           bundlerURL: options.bundlerURL,
-          startRoute: options.startRoute,
+          startRoute: clientPropsOverride?.startRoute ?? options.startRoute,
           fileResolver: options.fileResolver,
           skipEval: options.skipEval ?? false,
           logLevel: options.logLevel,
@@ -208,8 +217,13 @@ export const useClient: UseClient = ({ options, customSetup }, filesState) => {
   const runSandpack = useCallback(async (): Promise<void> => {
     await Promise.all(
       Object.keys(preregisteredIframes.current).map(async (clientId) => {
-        const iframe = preregisteredIframes.current[clientId];
-        clients.current[clientId] = await createClient(iframe, clientId);
+        const { iframe, clientPropsOverride = {} } =
+          preregisteredIframes.current[clientId];
+        clients.current[clientId] = await createClient(
+          iframe,
+          clientId,
+          clientPropsOverride
+        );
       })
     );
 
@@ -267,11 +281,22 @@ export const useClient: UseClient = ({ options, customSetup }, filesState) => {
   ]);
 
   const registerBundler = useCallback(
-    async (iframe: HTMLIFrameElement, clientId: string): Promise<void> => {
+    async (
+      iframe: HTMLIFrameElement,
+      clientId: string,
+      clientPropsOverride?: ClientPropsOverride
+    ): Promise<void> => {
       if (state.status === "running") {
-        clients.current[clientId] = await createClient(iframe, clientId);
+        clients.current[clientId] = await createClient(
+          iframe,
+          clientId,
+          clientPropsOverride
+        );
       } else {
-        preregisteredIframes.current[clientId] = iframe;
+        preregisteredIframes.current[clientId] = {
+          iframe,
+          clientPropsOverride,
+        };
       }
     },
     [createClient, state.status]

--- a/sandpack-react/src/hooks/useSandpackClient.ts
+++ b/sandpack-react/src/hooks/useSandpackClient.ts
@@ -8,6 +8,7 @@ import * as React from "react";
 
 import type { SandpackState } from "../types";
 import { generateRandomId } from "../utils/stringUtils";
+import type { ClientPropsOverride } from "../contexts/utils/useClient";
 
 import { useSandpack } from "./useSandpack";
 
@@ -28,7 +29,9 @@ interface UseSandpackClient {
  *
  * @category Hooks
  */
-export const useSandpackClient = (): UseSandpackClient => {
+export const useSandpackClient = (
+  clientPropsOverride?: ClientPropsOverride
+): UseSandpackClient => {
   const { sandpack, listen, dispatch } = useSandpack();
   const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
   const clientId = React.useRef<string>(generateRandomId());
@@ -38,7 +41,11 @@ export const useSandpackClient = (): UseSandpackClient => {
     const clientIdValue = clientId.current;
 
     if (iframeElement !== null) {
-      sandpack.registerBundler(iframeElement, clientIdValue);
+      sandpack.registerBundler(
+        iframeElement,
+        clientIdValue,
+        clientPropsOverride
+      );
     }
 
     return (): void => sandpack.unregisterBundler(clientIdValue);

--- a/sandpack-react/src/hooks/useSandpackPreviewProgress.ts
+++ b/sandpack-react/src/hooks/useSandpackPreviewProgress.ts
@@ -24,12 +24,22 @@ const mapProgressMessage = (
   }
 };
 
-export const useSandpackPreviewProgress = (timeout?: number) => {
+export const useSandpackPreviewProgress = (
+  props:
+    | {
+        timeout?: number;
+        clientId?: string;
+      }
+    | undefined
+) => {
   const [isReady, setIsReady] = React.useState(false);
   const [totalDependencies, setTotalDependencies] = React.useState<number>();
   const [loadingMessage, setLoadingMessage] = React.useState<null | string>(
     null
   );
+
+  const timeout = props?.timeout;
+  const clientId = props?.clientId;
 
   const { listen } = useSandpack();
 
@@ -63,7 +73,7 @@ export const useSandpackPreviewProgress = (timeout?: number) => {
         setIsReady(true);
         clearTimeout(timer);
       }
-    });
+    }, clientId);
 
     return (): void => {
       if (timer) {
@@ -71,7 +81,7 @@ export const useSandpackPreviewProgress = (timeout?: number) => {
       }
       unsubscribe();
     };
-  }, [isReady, totalDependencies, timeout]);
+  }, [clientId, isReady, totalDependencies, timeout]);
 
   return loadingMessage;
 };

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -19,6 +19,8 @@ import type { SANDBOX_TEMPLATES } from "./templates";
 
 import type { CodeEditorProps } from ".";
 
+import type { ClientPropsOverride } from "./contexts/utils/useClient";
+
 /**
  * ------------------------ Public documentation ------------------------
  *
@@ -541,7 +543,8 @@ export interface SandpackState {
   runSandpack: () => Promise<void>;
   registerBundler: (
     iframe: HTMLIFrameElement,
-    clientId: string
+    clientId: string,
+    clientPropsOverride?: ClientPropsOverride
   ) => Promise<void>;
   unregisterBundler: (clientId: string) => void;
   updateFile: (

--- a/website/docs/src/pages/advanced-usage/components.mdx
+++ b/website/docs/src/pages/advanced-usage/components.mdx
@@ -114,6 +114,7 @@ export default () => (
 | `showSandpackErrorOverlay`| Whether to show the `<ErrorOverlay>` component on top of the preview, if a runtime error happens. | `boolean` | `true` |
 | `showOpenNewtab` | | `boolean` | `true` |
 | `actionsChildren` | | JSX.Element | `null` |
+| `startRoute` | Overwrite the default starting route | `string` | `undefined` |
   
 </details>
 


### PR DESCRIPTION
## What kind of change does this pull request introduce?

<!-- Is it a Bug fix, feature, documentation update... -->

I'm trying to render two _Preview_ components that point to different pages (e.g. `/about` and `/careers`). This PR includes some rough changes and a Storybook story to better explain my intentions.

The core change is to add a `startRoute` prop to the Preview component that overrides the `startRoute` option that's passed to the Provider. When `createClient` is called in the `useClient` hook, the override value is used instead.

This idea could probably be extended for other things that may need an override, but for now, I explicitly exposed the `startRoute` functionality.

This _may_ be an unnecessary change.

Based on the [Preview Component documentation](https://sandpack.codesandbox.io/docs/advanced-usage/components#preview):

> There's nothing stopping you from rendering multiple previews in the same Provider. They will all be connected to the same state source, but they can for example point to different pages of the same application.

If there's already a way to do this, could someone on the core Sandpack team point me in the correct direction?

Thanks!

## What is the current behavior?

All Preview components start on the route defined by the `startRoute` option passed to the top-level Provider.

<!-- You can also link to an open issue here -->

## What is the new behavior?

A new `startRoute` prop has been added to the Preview component that lets you override the top-level Provider option.

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

I created a Storybook story `MultipleRoutePreviews` that uses React Router. It defines two routes and renders two Preview components that point to the different routes. When the story loads up, each Preview component starts on the correct route now.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation;
- [x] Storybook (if applicable);
- [ ] Tests;
- [ ] Ready to be merged;


<!-- feel free to add additional comments -->

This PR is still very rough. There may be better ways to accomplish what I'm trying to do and any proposed change would still require an update to the documentation.

<!-- Thank you for contributing! -->
