### PR TITLE
fix(sandpack-content): destroy current client in case it tries to run it again

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
   "packages": ["sandpack-client", "sandpack-react"],
-  "sandboxes": ["sowx8r", "11rikb"],
+  "sandboxes": ["sowx8r", "ooz9gz"],
   "node": "16"
 }

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -2,10 +2,9 @@
 import * as themes from "@codesandbox/sandpack-themes";
 import React from "react";
 
-import { SandpackCodeEditor, SandpackPreview } from "./components";
-import { useSandpack } from "./hooks";
+import { SandpackCodeEditor, SandpackConsole } from "./components";
 
-import { Sandpack, SandpackProvider } from "./";
+import { Sandpack, SandpackLayout, SandpackProvider } from "./";
 
 export default {
   title: "Intro/Playground",
@@ -46,36 +45,3 @@ console.log("foo");`,
     template="node"
   />
 );
-
-export const RunExample = () => {
-  return (
-    <div className="App">
-      <SandpackProvider
-        options={{
-          autorun: false,
-        }}
-        template="vanilla-ts"
-      >
-        <SandpackCodeEditor />
-        <SandpackPreview />
-        <RunButton />
-      </SandpackProvider>
-    </div>
-  );
-};
-
-// Allows running sandpack programatically
-// However, the bug is that the values are stale:
-function RunButton() {
-  const { sandpack } = useSandpack();
-
-  return (
-    <button
-      onClick={() => {
-        sandpack.runSandpack();
-      }}
-    >
-      Run
-    </button>
-  );
-}

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -2,9 +2,10 @@
 import * as themes from "@codesandbox/sandpack-themes";
 import React from "react";
 
-import { SandpackCodeEditor, SandpackConsole } from "./components";
+import { SandpackCodeEditor, SandpackPreview } from "./components";
+import { useSandpack } from "./hooks";
 
-import { Sandpack, SandpackLayout, SandpackProvider } from "./";
+import { Sandpack, SandpackProvider } from "./";
 
 export default {
   title: "Intro/Playground",
@@ -45,3 +46,36 @@ console.log("foo");`,
     template="node"
   />
 );
+
+export const RunExample = () => {
+  return (
+    <div className="App">
+      <SandpackProvider
+        options={{
+          autorun: false,
+        }}
+        template="vanilla-ts"
+      >
+        <SandpackCodeEditor />
+        <SandpackPreview />
+        <RunButton />
+      </SandpackProvider>
+    </div>
+  );
+};
+
+// Allows running sandpack programatically
+// However, the bug is that the values are stale:
+function RunButton() {
+  const { sandpack } = useSandpack();
+
+  return (
+    <button
+      onClick={() => {
+        sandpack.runSandpack();
+      }}
+    >
+      Run
+    </button>
+  );
+}

--- a/sandpack-react/src/contexts/utils/useClient.ts
+++ b/sandpack-react/src/contexts/utils/useClient.ts
@@ -208,7 +208,13 @@ export const useClient: UseClient = ({ options, customSetup }, filesState) => {
   const runSandpack = useCallback(async (): Promise<void> => {
     await Promise.all(
       Object.keys(preregisteredIframes.current).map(async (clientId) => {
+        // There's already a client if the same id, so we should destroy it
+        if (clients.current[clientId]) {
+          clients.current[clientId].destroy();
+        }
+
         const iframe = preregisteredIframes.current[clientId];
+
         clients.current[clientId] = await createClient(iframe, clientId);
       })
     );


### PR DESCRIPTION
If Sandpack tries to run `runSandpack` multiple times for the same cliend-id, it should first destroy the current instance and recreate the client again in order to wire up all listeners once again.

Closes https://github.com/codesandbox/sandpack/issues/852