### PR TITLE
chore(package.json): Build client in watch mode during react dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "format:check": "turbo run format:check --filter=\"@codesandbox/**\"",
     "-----": "-----",
     "dev:docs": "yarn workspace sandpack-docs dev",
-    "dev:react": "yarn workspace @codesandbox/sandpack-react dev",
+    "dev:react": "turbo run dev --filter=@codesandbox/sandpack-react --filter=@codesandbox/sandpack-client",
     "dev:landing": "yarn workspace sandpack-landing dev -p 3001",
     "dev:theme": "yarn workspace sandpack-theme dev -p 3002"
   },

--- a/sandpack-client/package.json
+++ b/sandpack-client/package.json
@@ -44,7 +44,8 @@
     "build:publish": "yarn build && gulp",
     "build:bundler": "gulp",
     "format": "prettier --write '**/*.{ts,tsx,js,jsx}'",
-    "format:check": "prettier --check '**/*.{ts,tsx}'"
+    "format:check": "prettier --check '**/*.{ts,tsx}'",
+    "dev": "yarn build -- --watch"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## What kind of change does this pull request introduce?

This PR involves a change to the `sandpack-react` Storybook dev process.

<!-- Is it a Bug fix, feature, documentation update... -->

## What is the current behavior?

Currently when you're working on the `sandpack-react` package via Storybook, there isn't an easy way for changes to the `sandpack-client` to be reflected immediately. You have to manually rebuild the `sandpack-client` on each change.

<!-- You can also link to an open issue here -->

## What is the new behavior?

When spinning up the `sandpack-react` Storybook dev environment, we start the `sandpack-client` build process in watch mode. This allows changes in the client to automatically be reflected during development in Storybook. This seems to be [how Turborepo recommends it to be done](https://turbo.build/repo/docs/handbook/publishing-packages/bundling#setting-up-a-dev-script).

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Clean up the `sandpack-client` dist files
2. Run `yarn react:dev`
3. Make a change to the `sandpack-client` directory
4. Watch the change trigger a rebuild that updates the Storybook dev environment

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation;
- [ ] Storybook (if applicable);
- [ ] Tests;
- [x] Ready to be merged;


<!-- feel free to add additional comments -->
There might already be a suggested way to accomplish what I'm trying to do. If that's the case, we can ignore this change and close the PR.

<!-- Thank you for contributing! -->
