### PR TITLE
fix(SandpackCodeEditor): add className prop

### DIFF
--- a/sandpack-react/src/components/CodeEditor/index.tsx
+++ b/sandpack-react/src/components/CodeEditor/index.tsx
@@ -17,6 +17,7 @@ export type CodeEditorRef = CodeMirrorRef;
 
 export interface CodeEditorProps {
   style?: React.CSSProperties;
+  className?: string;
   showTabs?: boolean;
   showLineNumbers?: boolean;
   showInlineErrors?: boolean;
@@ -74,6 +75,7 @@ export const SandpackCodeEditor = forwardRef<CodeMirrorRef, CodeEditorProps>(
       readOnly,
       showReadOnly,
       additionalLanguages,
+      className,
       ...props
     },
     ref
@@ -90,7 +92,7 @@ export const SandpackCodeEditor = forwardRef<CodeMirrorRef, CodeEditorProps>(
     };
 
     return (
-      <SandpackStack className={classNames("editor")} {...props}>
+      <SandpackStack className={classNames("editor", [className])} {...props}>
         {shouldShowTabs && <FileTabs closableTabs={closableTabs} />}
 
         <div className={classNames("code-editor", [editorClassName])}>


### PR DESCRIPTION
## What kind of change does this pull request introduce?

This change adds a `className` prop to the `SandpackCodeEditor` component that gets merged with the root `SandpackStack` classes. The motivation behind this change is that I'd like to style the editor using tailwind, which isn't possible with the current setup. The change is similar to the existing implementation in the [SandpackPreview component](https://github.com/codesandbox/sandpack/blob/main/sandpack-react/src/components/Preview/index.tsx#L158).

<!-- Is it a Bug fix, feature, documentation update... -->

## What is the current behavior?

The only way to style a `SandpackCodeEditor` component currently is to use the `style` prop.

<!-- You can also link to an open issue here -->

## What is the new behavior?

A new `className` prop has been added to the `SandpackCodeEditor` component to make it possible to style the editor using class names.

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

I added the `className` prop to a few stories in Storybook and was able to see that the `classes` were applied to the correct element in the DOM.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation;
- [ ] Storybook (if applicable);
- [ ] Tests;
- [x] Ready to be merged;


<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
