### PR TITLE
fix(Static Template): fix doctype injection

### DIFF
--- a/sandpack-client/src/clients/static/index.ts
+++ b/sandpack-client/src/clients/static/index.ts
@@ -86,9 +86,9 @@ export class SandpackStatic extends SandpackClient {
     let contentString = readBuffer(content);
 
     // Add the DOCTYPE tag
-    const docTypeRegex = /<!DOCTYPE*>/gi;
+    const docTypeRegex = /<!DOCTYPE.*>/gi;
     if (!docTypeRegex.test(contentString)) {
-      contentString = `<!DOCTYPE html>\n${content}`;
+      contentString = `<!DOCTYPE html>\n${contentString}`;
     }
 
     return contentString;


### PR DESCRIPTION
## What kind of change does this pull request introduce?

https://github.com/codesandbox/sandpack/issues/897

This looks like it made its way in as part of https://github.com/codesandbox/sandpack/pull/884. I'm a bit confused about how things were ever working though. Based on the change in this PR, it seems like things should have always been failing because `content` would have been converted to a string _and_ that if statement would have always been true because the Regex was wrong (i.e. missing the `.*`).

Sorry for not catching this on the first go around though. Hopefully, things should be good with this fix.

<!-- Is it a Bug fix, feature, documentation update... -->

## What is the current behavior?

The `Uint8Array` content array is converted to a string in the Static template rather than being decoded.

<!-- You can also link to an open issue here -->

## What is the new behavior?

The content is now properly decoded.

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

I just tried things in Storybook. I was able to reproduce the issue before making the change and then after making the change things seem to be working again.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation;
- [ ] Storybook (if applicable);
- [ ] Tests;
- [x] Ready to be merged;


<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
