### PR TITLE
fix(sandpack-react): disable LanguageTool extention for code editor

### DIFF
--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -293,6 +293,7 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
       });
 
       view.contentDOM.setAttribute("data-gramm", "false");
+      view.contentDOM.setAttribute("data-lt-active", "false");
       view.contentDOM.setAttribute(
         "aria-label",
         filePath ? `Code Editor for ${getFileName(filePath)}` : `Code Editor`


### PR DESCRIPTION
[LanguageTool](https://languagetool.org/) is an extension for web browsers to fix grammatical issues like [Grammarly](https://www.grammarly.com/). 

## What is the current behavior?

However, the extension shows errors in Sandpacks's editor that is not intended for codes.
![Screenshot from 2023-04-10 23-42-29](https://user-images.githubusercontent.com/64708228/230989305-1b9baed9-4562-45ca-898c-3632609f711b.png)


## What is the new behavior?

Disable the LanguageTool extension for code editor with `data-lt-active="false"` attribute.
