### PR TITLE
fix(sandpack-react): fix autoReload and honor showRunButton false

### DIFF
--- a/sandpack-react/src/components/CodeEditor/index.tsx
+++ b/sandpack-react/src/components/CodeEditor/index.tsx
@@ -87,8 +87,11 @@ export const SandpackCodeEditor = forwardRef<CodeMirrorRef, CodeEditorProps>(
 
     const classNames = useClassNames();
 
-    const handleCodeUpdate = (newCode: string): void => {
-      updateCode(newCode);
+    const handleCodeUpdate = (
+      newCode: string,
+      shouldUpdatePreview = true
+    ): void => {
+      updateCode(newCode, shouldUpdatePreview);
     };
 
     return (
@@ -106,7 +109,9 @@ export const SandpackCodeEditor = forwardRef<CodeMirrorRef, CodeEditorProps>(
             extensionsKeymap={extensionsKeymap}
             filePath={activeFile}
             initMode={initMode || sandpack.initMode}
-            onCodeUpdate={handleCodeUpdate}
+            onCodeUpdate={(newCode: string) =>
+              handleCodeUpdate(newCode, sandpack.autoReload ?? true)
+            }
             readOnly={readOnly || readOnlyFile}
             showInlineErrors={showInlineErrors}
             showLineNumbers={showLineNumbers}

--- a/sandpack-react/src/components/CodeEditor/index.tsx
+++ b/sandpack-react/src/components/CodeEditor/index.tsx
@@ -119,7 +119,7 @@ export const SandpackCodeEditor = forwardRef<CodeMirrorRef, CodeEditorProps>(
             wrapContent={wrapContent}
           />
 
-          {!sandpack.autoReload || (showRunButton && status === "idle") ? (
+          {showRunButton && (!sandpack.autoReload || status === "idle") ? (
             <RunButton />
           ) : null}
         </div>

--- a/sandpack-react/src/contexts/utils/useFiles.ts
+++ b/sandpack-react/src/contexts/utils/useFiles.ts
@@ -27,7 +27,7 @@ interface FilesOperations {
   resetFile: (path: string) => void;
   resetAllFiles: () => void;
   setActiveFile: (path: string) => void;
-  updateCurrentFile: (code: string) => void;
+  updateCurrentFile: (code: string, shouldUpdatePreview?: boolean) => void;
   updateFile: (
     pathOrFiles: string | SandpackFiles,
     code?: string,
@@ -121,8 +121,8 @@ export const useFiles: UseFiles = (props) => {
         setState((prev) => ({ ...prev, activeFile }));
       }
     },
-    updateCurrentFile: (code: string): void => {
-      updateFile(state.activeFile, code);
+    updateCurrentFile: (code: string, shouldUpdatePreview = true): void => {
+      updateFile(state.activeFile, code, shouldUpdatePreview);
     },
     updateFile,
     addFile: updateFile,

--- a/sandpack-react/src/hooks/useActiveCode.ts
+++ b/sandpack-react/src/hooks/useActiveCode.ts
@@ -9,7 +9,7 @@ import { useSandpack } from "./useSandpack";
 export const useActiveCode = (): {
   code: string;
   readOnly: boolean;
-  updateCode: (newCode: string) => void;
+  updateCode: (newCode: string, shouldUpdatePreview: boolean) => void;
 } => {
   const { sandpack } = useSandpack();
 

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -584,7 +584,7 @@ export interface SandpackState {
     code?: string,
     shouldUpdatePreview?: boolean
   ) => void;
-  updateCurrentFile: (newCode: string) => void;
+  updateCurrentFile: (newCode: string, shouldUpdatePreview?: boolean) => void;
   openFile: (path: string) => void;
   closeFile: (path: string) => void;
   deleteFile: (path: string, shouldUpdatePreview?: boolean) => void;


### PR DESCRIPTION
## What kind of change does this pull request introduce?

<!-- Is it a Bug fix, feature, documentation update... -->
This fixes a bug where `autoReload={false}` doesn't turn off auto reload on code change. Additionally, it changes the logic for the Run button so that `showRunButton={false}` is honored even when `autoReload` is off. 

## What is the current behavior?

<!-- You can also link to an open issue here -->
1. When `autoReload` is set to `false` and a file is edited, the preview automatically reloads anyway.
2. When both `autoReload` and `showRunButton` are set to `false` the code editor shows the Run button. 

## What is the new behavior?

<!-- if this is a feature change -->

1. `autoReload={false}` will prevent the preview from reloading when the code changes.
2. `showRunButton={false}` will prevent the Run button from ever appearing.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. In Storybook, test PRESETS > Sandpack: options > Auto Reload. Adjusting the code should not trigger a reload of the preview.
2. I also played with the basic component example in `sandpack-react/src/components/CodeEditor/CodeEditor.stories.tsx` using Storybook to test when the Run button was shown or hidden.
The following will hide the Run button and not automatically reload the preview:
```tsx
export const Component: Story<CodeEditorProps> = (args) => (
  <SandpackProvider
    options={{
      autoReload: false,
    }}
  >
    <SandpackThemeProvider>
      <SandpackCodeEditor {...args} showRunButton={false} />
      <SandpackPreview />
    </SandpackThemeProvider>
  </SandpackProvider>
);
```

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation;
- [ ] Storybook (if applicable);
- [ ] Tests;
- [ ] Ready to be merged;


<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
