### PR TITLE
fix(useClient): track all clients and update clients on runSandpack

### DIFF
--- a/sandpack-client/src/clients/static/index.ts
+++ b/sandpack-client/src/clients/static/index.ts
@@ -79,6 +79,8 @@ export class SandpackStatic extends SandpackClient {
         "accelerometer; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; clipboard-write;"
       );
     }
+
+    this.updateSandbox();
   }
 
   private injectContentIntoHead(

--- a/sandpack-client/src/clients/static/index.ts
+++ b/sandpack-client/src/clients/static/index.ts
@@ -80,6 +80,7 @@ export class SandpackStatic extends SandpackClient {
       );
     }
 
+    // Dispatch very first compile action
     this.updateSandbox();
   }
 

--- a/sandpack-react/src/contexts/utils/useClient.ts
+++ b/sandpack-react/src/contexts/utils/useClient.ts
@@ -173,7 +173,7 @@ export const useClient: UseClient = (
         }
       );
 
-      if (shouldSetTimeout) {
+      if (typeof unsubscribe.current !== "function") {
         unsubscribe.current = client.listen(handleMessage);
       }
 

--- a/sandpack-react/src/contexts/utils/useClient.ts
+++ b/sandpack-react/src/contexts/utils/useClient.ts
@@ -138,9 +138,13 @@ export const useClient: UseClient = (
       }
 
       /**
-       * Only sets a timeout if no bundler is running
+       * Subscribe inside the context with the first client that gets instantiated.
+       * This subscription is for global states like error and timeout, so no need for a per client listen
+       * Also, set the timeout timer only when the first client is instantiated
        */
-      if (Object.keys(clients.current).length === 0) {
+      const shouldSetTimeout = typeof unsubscribe.current !== "function";
+
+      if (shouldSetTimeout) {
         timeoutHook.current = setTimeout(() => {
           unregisterAllClients();
           setState((prev) => ({ ...prev, status: "timeout" }));
@@ -169,12 +173,7 @@ export const useClient: UseClient = (
         }
       );
 
-      /**
-       * Subscribe inside the context with the first client that gets instantiated.
-       * This subscription is for global states like error and timeout, so no need for a per client listen
-       * Also, set the timeout timer only when the first client is instantiated
-       */
-      if (typeof unsubscribe.current !== "function") {
+      if (shouldSetTimeout) {
         unsubscribe.current = client.listen(handleMessage);
       }
 

--- a/sandpack-react/src/contexts/utils/useClient.ts
+++ b/sandpack-react/src/contexts/utils/useClient.ts
@@ -137,10 +137,15 @@ export const useClient: UseClient = (
         clearTimeout(timeoutHook.current);
       }
 
-      timeoutHook.current = setTimeout(() => {
-        unregisterAllClients();
-        setState((prev) => ({ ...prev, status: "timeout" }));
-      }, timeOut);
+      /**
+       * Only sets a timeout if no bundler is running
+       */
+      if (Object.keys(clients.current).length === 0) {
+        timeoutHook.current = setTimeout(() => {
+          unregisterAllClients();
+          setState((prev) => ({ ...prev, status: "timeout" }));
+        }, timeOut);
+      }
 
       const client = await loadSandpackClient(
         iframe,

--- a/sandpack-react/src/presets/CustomSandpack.stories.tsx
+++ b/sandpack-react/src/presets/CustomSandpack.stories.tsx
@@ -275,7 +275,10 @@ export const MultiplePreviewsAndListeners: React.FC = () => {
 
   return (
     <>
-      <SandpackProvider template="react">
+      <SandpackProvider
+        template="static"
+        options={{ autorun: false, autoReload: false }}
+      >
         {new Array(listenersCount).fill(" ").map((pr) => (
           <SandpackListener key={pr} />
         ))}
@@ -530,41 +533,5 @@ body {
         </SandpackProvider>
       </div>
     </div>
-  );
-};
-
-const RunSandpackButtonComponents = () => {
-  const { sandpack } = useSandpack();
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-
-  return (
-    <div style={{ display: "flex", gap: 8, padding: 16 }}>
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        <button
-          onClick={() => {
-            sandpack.registerBundler(iframeRef.current!, "custom");
-          }}
-        >
-          Register
-        </button>
-        <button onClick={sandpack.runSandpack}>Custom Run</button>
-      </div>
-      <iframe ref={iframeRef} />
-    </div>
-  );
-};
-
-export const RunSandpackButton = () => {
-  return (
-    <SandpackProvider
-      template="static"
-      options={{ autoReload: false, autorun: false }}
-    >
-      <SandpackLayout>
-        <SandpackCodeEditor showRunButton />
-        <SandpackPreview />
-      </SandpackLayout>
-      <RunSandpackButtonComponents />
-    </SandpackProvider>
   );
 };

--- a/sandpack-react/src/presets/CustomSandpack.stories.tsx
+++ b/sandpack-react/src/presets/CustomSandpack.stories.tsx
@@ -532,3 +532,39 @@ body {
     </div>
   );
 };
+
+const RunSandpackButtonComponents = () => {
+  const { sandpack } = useSandpack();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  return (
+    <div style={{ display: "flex", gap: 8, padding: 16 }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <button
+          onClick={() => {
+            sandpack.registerBundler(iframeRef.current!, "custom");
+          }}
+        >
+          Register
+        </button>
+        <button onClick={sandpack.runSandpack}>Custom Run</button>
+      </div>
+      <iframe ref={iframeRef} />
+    </div>
+  );
+};
+
+export const RunSandpackButton = () => {
+  return (
+    <SandpackProvider
+      template="static"
+      options={{ autoReload: false, autorun: false }}
+    >
+      <SandpackLayout>
+        <SandpackCodeEditor showRunButton />
+        <SandpackPreview />
+      </SandpackLayout>
+      <RunSandpackButtonComponents />
+    </SandpackProvider>
+  );
+};

--- a/sandpack-react/src/presets/CustomSandpack.stories.tsx
+++ b/sandpack-react/src/presets/CustomSandpack.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useId, useRef, useState } from "react";
 
 import { stackClassName } from "../";
 import { tabButton } from "../";
@@ -256,10 +256,11 @@ export const MultiplePreviews: React.FC = () => {
 
 const SandpackListener: React.FC = () => {
   const { listen } = useSandpack();
+  const id = useId();
 
   useEffect(() => {
     // eslint-disable-next-line no-console
-    const unsubscribe = listen((msg) => console.log(msg));
+    const unsubscribe = listen((msg) => console.log(id, msg));
 
     return unsubscribe;
   }, [listen]);
@@ -276,11 +277,11 @@ export const MultiplePreviewsAndListeners: React.FC = () => {
   return (
     <>
       <SandpackProvider
+        options={{ autorun: true, autoReload: true }}
         template="static"
-        options={{ autorun: false, autoReload: false }}
       >
-        {new Array(listenersCount).fill(" ").map((pr) => (
-          <SandpackListener key={pr} />
+        {new Array(listenersCount).fill(" ").map((pr, index) => (
+          <SandpackListener key={index} />
         ))}
         <SandpackLayout>
           <SandpackCodeEditor />


### PR DESCRIPTION
## What kind of change does this pull request introduce?

A proposed solution for https://github.com/codesandbox/sandpack/issues/918. That bug is about how the `runSandpack` function doesn't work for the `static` template. While working through determining the root cause for that problem, I ran into a few other problems around how we register bundlers.

### Preregistered iFrame Object

When we register a bundler it's only put into the `preregisteredIframes` object if the `useClient` status isn't `running`. The problem is that `runSandpack` only reruns clients that are in the `preregisteredIframes` object, which means if you register a client after things have started up, they won't get picked up by the `runSandpack` function.

### Static Template runSandpack function

When creating a `runtime` client, there's a [global listener that calls updateSandbox](https://github.com/codesandbox/sandpack/blob/main/sandpack-client/src/clients/runtime/index.ts#L126) after the client has initialized. This call to `updateSandbox` is how a newly created client displays its view when `runSandpack` is invoked. The reason the `static` template isn't working is that we don't have a step to call `updateSandbox`. I've added this step to the `static` template constructor and things seem to work.

One thing to note is that this means in a situation where you have `autorun` set to `true`, the `updateSandbox` function will initially be called twice (once from the `static` template constructor and once from [the useClient's watchFileChanges effect](https://github.com/codesandbox/sandpack/blob/main/sandpack-react/src/contexts/utils/useClient.ts#L505)). While this isn't ideal, this is currently how the `runtime` client works as well, so there's consistency.

### Leaking Listeners

This one is harder to prove, but if the `useClient` hook is in a `running` state and you _register_ a new bundler, the code immediately calls `createClient` without cleaning up any existing clients for a given client ID. This means any stale listeners will still be present and won't be cleaned up.

### Examples

I made a [Code Sandbox that better outlines the problems mentioned above](https://codesandbox.io/s/aged-star-1jo1si?file=/src/App.tsx). Verifying the leaking listeners is harder to show in a Code Sandbox, but to verify that problem, you can:
1. Copy the code from the Sandbox
2. Create a story in StoryBook with that code (`template: vanilla` and `autorun: true`)
3. Add a `console.log` statement to the [first line of the runtime client global listener](https://github.com/codesandbox/sandpack/blob/main/sandpack-client/src/clients/runtime/index.ts#L102)
4. Every time you press `Register Bundler`, you should notice that the number of console logs grows because old listeners aren't getting cleaned up

<!-- Is it a Bug fix, feature, documentation update... -->

## What is the current behavior?

Everything that is mentioned above.

<!-- You can also link to an open issue here -->

## What is the new behavior?

1. `static` template calls `updateSandbox` as part of the constructor (`runSandpack` should work now)
2. Rename `preregisteredIframes` to `registeredIframes` and track _every_ client that's registered. This way when `runSandpack` is called, it'll work for clients that are registered after `useClient` is in a `running` state
3. Update `createClient` so the first step is to clean up any existing clients with the same client id (removes leaking listeners)

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

I tried the above examples with the code changes. Everything seems to be working as expected. I also added a Storybook story with a similar setup to the Code Sandbox example.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation;
- [x] Storybook (if applicable);
- [ ] Tests;
- [x] Ready to be merged;


<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
