### PR TITLE
feat: add sandbox-id prop to compile

### DIFF
--- a/sandpack-client/src/clients/runtime/index.ts
+++ b/sandpack-client/src/clients/runtime/index.ts
@@ -250,6 +250,7 @@ export class SandpackRuntime extends SandpackClient {
       logLevel: this.options.logLevel ?? SandpackLogLevel.Info,
       customNpmRegistries: this.options.customNpmRegistries,
       teamId: this.options.teamId,
+      sandboxId: this.options.sandboxId,
     });
   }
 

--- a/sandpack-client/src/clients/runtime/types.ts
+++ b/sandpack-client/src/clients/runtime/types.ts
@@ -79,6 +79,7 @@ export type SandpackRuntimeMessage = BaseSandpackMessage &
         logLevel?: SandpackLogLevel;
         customNpmRegistries?: NpmRegistry[];
         teamId?: string;
+        sandboxId?: string;
       }
     | {
         type: "refresh";

--- a/sandpack-client/src/types.ts
+++ b/sandpack-client/src/types.ts
@@ -61,6 +61,11 @@ export interface ClientOptions {
   customNpmRegistries?: NpmRegistry[];
 
   /**
+   * CodeSandbox sandbox id: used internally by codesandbox
+   */
+  sandboxId?: string;
+
+  /**
    * CodeSandbox team id: with this information, bundler can connect to CodeSandbox
    * and unlock a few capabilities
    */

--- a/sandpack-react/src/contexts/utils/useClient.ts
+++ b/sandpack-react/src/contexts/utils/useClient.ts
@@ -69,7 +69,7 @@ type UseClient = (
 ) => [SandpackConfigState, UseClientOperations];
 
 export const useClient: UseClient = (
-  { options, customSetup, teamId },
+  { options, customSetup, teamId, sandboxId },
   filesState
 ) => {
   options ??= {};
@@ -165,7 +165,8 @@ export const useClient: UseClient = (
           showLoadingScreen: false,
           reactDevTools: state.reactDevTools,
           customNpmRegistries: customSetup?.npmRegistries,
-          teamId: teamId,
+          teamId,
+          sandboxId,
         }
       );
 

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -431,6 +431,7 @@ interface SandpackRootProps<
   customSetup?: SandpackSetup;
   theme?: SandpackThemeProp;
   teamId?: string;
+  sandboxId?: string;
 }
 
 export interface SandpackInternalOptions<


### PR DESCRIPTION
This should allow us to use sandpack at codesandbox with all the caching features we currently use