### PR TITLE
feat: support external esm module scripts

### DIFF
--- a/sandpack-client/src/clients/runtime/types.ts
+++ b/sandpack-client/src/clients/runtime/types.ts
@@ -11,6 +11,7 @@ import type {
   SandpackErrorMessage,
   SandpackLogLevel,
   SandpackMessageConsoleMethods,
+  ExternalScriptResource
 } from "../..";
 
 export type SandpackRuntimeMessage = BaseSandpackMessage &
@@ -66,7 +67,7 @@ export type SandpackRuntimeMessage = BaseSandpackMessage &
         version: number;
         isInitializationCompile?: boolean;
         modules: Modules;
-        externalResources: string[];
+        externalResources?: Array<string | ExternalScriptResource>;
         hasFileResolver: boolean;
         disableDependencyPreprocessing?: boolean;
         template?: string | ITemplate;

--- a/sandpack-client/src/types.ts
+++ b/sandpack-client/src/types.ts
@@ -5,7 +5,7 @@ export interface ClientOptions {
   /**
    * Paths to external resources
    */
-  externalResources?: string[];
+  externalResources?: Array<string | ExternalScriptResource>;
   /**
    * Location of the bundler.
    */
@@ -70,6 +70,11 @@ export interface ClientOptions {
    * and unlock a few capabilities
    */
   teamId?: string;
+}
+
+export interface ExternalScriptResource {
+  type: "module" | "importmap" | undefined;
+  src: string;
 }
 
 export interface SandboxSetup {

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -12,6 +12,7 @@ import type {
   UnsubscribeFunction,
   SandpackLogLevel,
   NpmRegistry,
+  ExternalScriptResource
 } from "@codesandbox/sandpack-client";
 import type React from "react";
 
@@ -171,7 +172,8 @@ export interface SandpackOptions {
   startRoute?: string;
   skipEval?: boolean;
   fileResolver?: FileResolver;
-  externalResources?: string[];
+  
+  externalResources?: Array<string | ExternalScriptResource>;
 }
 
 /**
@@ -460,7 +462,7 @@ export interface SandpackInternalOptions<
   startRoute?: string;
   skipEval?: boolean;
   fileResolver?: FileResolver;
-  externalResources?: string[];
+  externalResources?: Array<string | ExternalScriptResource>;
   classes?: Record<string, string>;
 }
 

--- a/website/docs/src/pages/advanced-usage/client.mdx
+++ b/website/docs/src/pages/advanced-usage/client.mdx
@@ -291,7 +291,7 @@ The `getCodeSandboxURL` method creates a sandbox from the current files and retu
   /**
    * Paths to external resources
    */
-  externalResources?: string[];
+  externalResources?: Array<string | ExternalScriptResource>;
   /**
    * Location of the bundler. Defaults to `${version}-sandpack.codesandbox.io`
    */


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Adds support for type=module for externalResource scripts
Related discussion: https://github.com/codesandbox/sandpack/discussions/998

## What is the current behavior?

You can only pass in strings and can't modify attributes on the script element. 

## What is the new behavior?

You can pass in a new object in the externalResources array that defines the [type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type) and [src](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#src)

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

I wanted this feature so that I can use sandpack to build a playground for my design system library. we use web components and es modules. The easiest way for me to test this was to try and get our library working, but any other esm script will do. I've also tested this in a separate React app locally using symlinks. 

1. Go to CustomSandpack.stories.tsx
2. Add module to externalResources

```
              {
                type: "module",
                src: "https://unpkg.com/@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.esm.js"
              },
              
```
3. In the HiddenHeadTags function, add: 

```
<body class="flex items-center justify-center">
  <rux-button icon="apps">submit</rux-button>
  <button class="p-4 bg-white rounded" onClick="alertTest()">Alert</button>
</body>
```

Boot up the dev storybook and you should see a custom button element.

## Checklist

- [x] Documentation;
- [x] Storybook (if applicable);
- [ ] Tests;
- [ ] Ready to be merged;


I could use some direction regarding testing if you think this needs some. I'm also not 100% clear on how/where to document. I will happily update if this approach is validated. 
