### PR TITLE
feat: improve system color scheme support and documentation

### DIFF
--- a/sandpack-react/src/components/ReactDevTools/index.tsx
+++ b/sandpack-react/src/components/ReactDevTools/index.tsx
@@ -9,7 +9,7 @@ const devToolClassName = css({
   width: "100%",
 });
 
-type DevToolsTheme = "dark" | "light";
+type DevToolsTheme = "dark" | "light" | "auto";
 
 export const SandpackReactDevTools = ({
   clientId,

--- a/sandpack-react/src/hooks/useSandpackTheme.ts
+++ b/sandpack-react/src/hooks/useSandpackTheme.ts
@@ -9,7 +9,7 @@ import type { SandpackTheme } from "../types";
 export const useSandpackTheme = (): {
   theme: SandpackTheme;
   themeId: string;
-  themeMode: "dark" | "light";
+  themeMode: "dark" | "light" | "auto";
 } => {
   const { theme, id, mode } = React.useContext(SandpackThemeContext);
   return { theme, themeId: id, themeMode: mode };

--- a/sandpack-react/src/styles/themeContext.tsx
+++ b/sandpack-react/src/styles/themeContext.tsx
@@ -35,7 +35,7 @@ const wrapperClassName = css({
 const SandpackThemeContext = React.createContext<{
   theme: SandpackTheme;
   id: string;
-  mode: "dark" | "light";
+  mode: "dark" | "light" | "auto";
 }>({
   theme: defaultLight,
   id: "light",
@@ -51,12 +51,33 @@ const SandpackThemeProvider: React.FC<
     children?: React.ReactNode;
   }
 > = ({ theme: themeFromProps, children, className, ...props }) => {
-  const { theme, id, mode } = standardizeTheme(themeFromProps);
+  const [prefferedTheme, setPreferredTheme] = React.useState<
+    SandpackThemeProp | undefined
+  >(themeFromProps);
+  const { theme, id, mode } = standardizeTheme(prefferedTheme);
   const classNames = useClassNames();
 
   const themeClassName = React.useMemo(() => {
     return createTheme(id, standardizeStitchesTheme(theme));
   }, [theme, id]);
+
+  React.useEffect(() => {
+    if (themeFromProps !== "auto") return;
+
+    const colorSchemeChange = ({ matches }: MediaQueryListEvent) => {
+      setPreferredTheme(matches ? "dark" : "light");
+    };
+
+    window
+      .matchMedia("(prefers-color-scheme: dark)")
+      .addEventListener("change", colorSchemeChange);
+
+    return () => {
+      window
+        .matchMedia("(prefers-color-scheme: dark)")
+        .removeEventListener("change", colorSchemeChange);
+    };
+  }, [themeFromProps]);
 
   return (
     <SandpackThemeContext.Provider value={{ theme, id, mode }}>

--- a/website/docs/src/components/Themes.jsx
+++ b/website/docs/src/components/Themes.jsx
@@ -27,13 +27,22 @@ export default function Themes() {
   };
 
   const predefinedThemes = ["auto", "dark", "light"].includes(current);
-  const codeBlock = predefinedThemes
-    ? `// Predefined theme
-    
-<Sandpack theme="${current}" />`
-    : `import { ${current} } from "@codesandbox/sandpack-themes";
+  const codeBlock = (() => {
+    if (current === "auto") {
+      return `// System color scheme (light or dark)
+      
+<Sandpack theme="${current}" />`;
+    }
 
+    if (predefinedThemes)
+      return `// Predefined theme
+    
+<Sandpack theme="${current}" />`;
+
+    return `import { ${current} } from "@codesandbox/sandpack-themes";
+    
 <Sandpack theme={${current}} />;`;
+  })();
 
   return (
     <div>


### PR DESCRIPTION
This improves the system color scheme support by listening to system color changes, and setting a preferrable color scheme to the sandpack theme context. Plus, it improves the documentation by mentioning that "auto" value will reflects the system color scheme, which can be the default values (light or dark)