### PR TITLE
fix: add `allow-downloads` to iframes

### DIFF
--- a/sandpack-client/src/clients/runtime/index.ts
+++ b/sandpack-client/src/clients/runtime/index.ts
@@ -82,7 +82,7 @@ export class SandpackRuntime extends SandpackClient {
     if (!this.iframe.getAttribute("sandbox")) {
       this.iframe.setAttribute(
         "sandbox",
-        "allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+        "allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts allow-downloads allow-pointer-lock"
       );
 
       this.iframe.setAttribute(

--- a/sandpack-client/src/clients/static/index.ts
+++ b/sandpack-client/src/clients/static/index.ts
@@ -81,7 +81,7 @@ export class SandpackStatic extends SandpackClient {
     if (!this.iframe.getAttribute("sandbox")) {
       this.iframe.setAttribute(
         "sandbox",
-        "allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+        "allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts allow-downloads allow-pointer-lock"
       );
 
       this.iframe.setAttribute(


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Add the `sandbox="allow-downloads"` attribute to iframes. See https://github.com/codesandbox/codesandbox-client/pull/8253 for more context.

I'm not 100% sure whether this is the right fix, however:
- In production, the iframe on https://codesandbox.io/p/sandbox/allow-downloads-repro-py27jv contains the `allow="accelerometer; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; clipboard-write;"` attribute.
- The string `clipboard-write` is nowhere to be found in the `codesandbox-client` repo. But the value of the attribute literally matches how sandpack sets it.
- Does it mean sandpack is actually used in production to power sandboxes, therefore adding `allow-downloads` here will fix the regression for preview sandboxes? 🤔

<!-- Is it a Bug fix, feature, documentation update... -->

## What is the current behavior?

No `allow-downloads` (https://github.com/codesandbox/codesandbox-client/issues/5936), which had been fixed by https://github.com/codesandbox/codesandbox-client/pull/5163 and https://github.com/codesandbox/codesandbox-client/pull/6384 but regressed again.

<!-- You can also link to an open issue here -->

## What is the new behavior?

If I understand correctly, updating the code here should fix the issue for sandbox previews (e.g. https://codesandbox.io/p/sandbox/allow-downloads-repro-py27jv).

The new list of sandbox permissions matches the behavior in https://github.com/codesandbox/codesandbox-client/blob/45862c7b9c382abce725f1272c3aed560162776a/packages/common/src/components/Preview/index.tsx#L648

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

Not sure how to let codesandbox pick up the change here, but unit tests pass. Let me know if I'm on the right path!

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] ~~Documentation;~~
- [x] ~~Storybook (if applicable);~~
- [x] ~~Tests;~~
- [ ] Ready to be merged;


<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
