### PR TITLE
fix: Update CodeMirror View when autoReload changed

### DIFF
--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -131,7 +131,10 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
     );
 
     const classNames = useClassNames();
-    const { listen } = useSandpack();
+    const {
+      listen,
+      sandpack: { autoReload },
+    } = useSandpack();
 
     const prevExtension = React.useRef<Extension[]>([]);
     const prevExtensionKeymap = React.useRef<KeyBinding[]>([]);
@@ -319,6 +322,7 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
       themeId,
       sortedDecorators,
       readOnly,
+      autoReload,
     ]);
 
     React.useEffect(

--- a/sandpack-react/src/presets/CustomSandpack.stories.tsx
+++ b/sandpack-react/src/presets/CustomSandpack.stories.tsx
@@ -20,6 +20,9 @@ import {
   SandpackStack,
   UnstyledOpenInCodeSandboxButton,
   SandpackFileExplorer,
+  SandpackConsumer,
+  CodeEditor,
+  type SandpackContext,
 } from "../";
 import { useSandpack } from "../hooks/useSandpack";
 
@@ -38,6 +41,69 @@ export const UsingSandpackLayout: React.FC = () => (
     </SandpackLayout>
   </SandpackProvider>
 );
+
+export const UsingMultipleEditor: React.FC = (props) => {
+  const [isAutoReload, setAutoReload] = React.useState(true);
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "500px",
+      }}
+    >
+      <SandpackProvider
+        {...props}
+        options={{ initMode: "immediate", autoReload: isAutoReload }}
+        template="static"
+      >
+        <SandpackConsumer>
+          {(context: SandpackContext | null) => {
+            if (!context) return <></>;
+
+            const { files, updateFile, autoReload } = context;
+            const fileListValues = Object.values(files);
+            const fileListKeys = Object.keys(files);
+
+            return (
+              <SandpackLayout>
+                <SandpackStack style={{ padding: "10px 0" }}>
+                  <CodeEditor
+                    code={fileListValues[0].code}
+                    filePath={fileListKeys[0]}
+                    initMode="immediate"
+                    onCodeUpdate={(newCode) => {
+                      updateFile(fileListKeys[0], newCode, autoReload);
+                    }}
+                  />
+                </SandpackStack>
+
+                <SandpackStack style={{ padding: "10px 0" }}>
+                  <CodeEditor
+                    code={fileListValues[1].code}
+                    filePath={fileListKeys[1]}
+                    initMode="immediate"
+                    onCodeUpdate={(newCode) => {
+                      updateFile(fileListKeys[1], newCode, autoReload);
+                    }}
+                  />
+                </SandpackStack>
+
+                <SandpackPreview
+                  actionsChildren={
+                    <button onClick={() => setAutoReload((prev) => !prev)}>
+                      Toggle autoReload to {JSON.stringify(!autoReload)}
+                    </button>
+                  }
+                />
+              </SandpackLayout>
+            );
+          }}
+        </SandpackConsumer>
+      </SandpackProvider>
+    </div>
+  );
+};
 
 export const UsingVisualElements: React.FC = () => (
   <SandpackProvider options={{ activeFile: "/App.js" }} template="react">


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Updates CodeMirror View constructor's useEffect's dependencies to make sure when `autoReload` option is changed we have re-evaluated `onCodeUpdate` version.

## What is the current behavior?

When we have a custom editors setup just like the examples shown in Doc > Quickstart > Multiple Editors, `autoReload` update doesn't work out because CodeMirror View doesn't re-evaluate `onCodeUpdate` so that we can't send the latest value of `shouldUpdatePreview`.

## What is the new behavior?

`onCodeUpdate` callback will be re-evaluated once `autoReload` option is changed.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

Created a Story to test out everything works as expected.

## Checklist

- [ ] Documentation;
- [x] Storybook (if applicable);
- [ ] Tests;
- [x] Ready to be merged;