### PR TITLE
fix: Theme state logic to account for non-prefers-color-scheme usage

### DIFF
--- a/sandpack-react/src/styles/themeContext.tsx
+++ b/sandpack-react/src/styles/themeContext.tsx
@@ -62,7 +62,10 @@ const SandpackThemeProvider: React.FC<
   }, [theme, id]);
 
   React.useEffect(() => {
-    if (themeFromProps !== "auto") return;
+    if (themeFromProps !== "auto") {
+      setPreferredTheme(themeFromProps);
+      return;
+    }
 
     const colorSchemeChange = ({ matches }: MediaQueryListEvent) => {
       setPreferredTheme(matches ? "dark" : "light");

--- a/sandpack-react/src/themes/Theme.stories.tsx
+++ b/sandpack-react/src/themes/Theme.stories.tsx
@@ -1,9 +1,10 @@
 import { storiesOf } from "@storybook/react";
 import React from "react";
+import { useState } from "react";
 
 import { Sandpack } from "../";
 
-import { SANDPACK_THEMES } from ".";
+import { SANDPACK_THEMES, defaultLight, defaultDark } from ".";
 
 const stories = storiesOf("presets/Themes", module);
 
@@ -21,3 +22,28 @@ Object.keys(SANDPACK_THEMES).forEach((themeName) =>
     />
   ))
 );
+
+export const ThemeSwitcher = () => {
+  const [theme, setTheme] = useState("light");
+
+  return (
+    <div>
+      <select onChange={(e) => setTheme(e.target.value)} value={theme}>
+        <option value="light">light</option>
+        <option value="dark">dark</option>
+      </select>
+      <Sandpack
+        options={{
+          showLineNumbers: true,
+          showInlineErrors: true,
+          showNavigator: true,
+          showTabs: true,
+        }}
+        template="react"
+        theme={theme === "light" ? defaultLight : defaultDark}
+      />
+    </div>
+  );
+};
+
+stories.add("theme-switcher", () => <ThemeSwitcher />);


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Fixes a regression where themes are not updated on change. 

Closes: #1080 

## What is the current behavior?

Themes don't change when the theme prop is updated 

## What is the new behavior?

Themes now change as expected

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

- `yarn dev:react`
-`open http://localhost:6006/?path=/story/presets-themes--theme-switcher`
- Toggle select box
- Works ✅ 

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation;
- [x] Storybook (if applicable);
- [x] Tests;
- [x] Ready to be merged;


<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
