### PR TITLE
Keep the metadata of a file when updating the code

### DIFF
--- a/sandpack-react/src/contexts/utils/useFiles.test.ts
+++ b/sandpack-react/src/contexts/utils/useFiles.test.ts
@@ -7,6 +7,7 @@ import { VANILLA_TEMPLATE } from "../../templates";
 import { getSandpackStateFromProps } from "../../utils/sandpackUtils";
 
 import { useFiles } from "./useFiles";
+import {SandpackBundlerFile} from "@codesandbox/sandpack-client/src";
 
 describe(useFiles, () => {
   it("should returns an initial state, which is the default template", () => {
@@ -125,4 +126,25 @@ describe(useFiles, () => {
     expect(result.current[0].files["/App.js"]).toEqual({ code: `Foo` });
     expect(result.current[0].files["/index.js"]).toEqual({ code: `Baz` });
   });
+  it("doesn't override the activeFile's metadata", () => {
+    const {result} = renderHook(() => useFiles({
+      template: "react",
+      files: {
+        "/App.js": {
+          code: "export default function App() { return <h1>Hello world</h1>}",
+          readOnly: true,
+          someOtherMetadata: "foo"
+        } as SandpackBundlerFile
+      }
+    }));
+
+    act(() => {
+      result.current[1].updateFile("/App.js", "console.log(10)");
+    });
+    expect(result.current[0].files["/App.js"]).toEqual({
+        code: "console.log(10)",
+        readOnly: true,
+        someOtherMetadata: "foo"
+    });
+  })
 });

--- a/sandpack-react/src/contexts/utils/useFiles.ts
+++ b/sandpack-react/src/contexts/utils/useFiles.ts
@@ -76,7 +76,10 @@ export const useFiles: UseFiles = (props) => {
       if (typeof pathOrFiles === "string" && typeof code === "string") {
         files = {
           ...files,
-          [pathOrFiles]: { code },
+          [pathOrFiles]: {
+            ...files[pathOrFiles],
+            code
+          },
         };
       } else if (typeof pathOrFiles === "object") {
         files = { ...files, ...convertedFilesToBundlerFiles(pathOrFiles) };


### PR DESCRIPTION
## What kind of change does this pull request introduce?
It prevents the code editor from overriding metadata information inside of a file, like readOnly, hidden, or any other custom data provided

## What is the current behavior?
The current behavior overrides the contents of the file with only the `{ code }` value, when the `updateFile` function is called using a string only, this is then also used by the code editor internally. I had made an issue here https://github.com/codesandbox/sandpack/issues/1084

## What is the new behavior?
It keeps the metadata of a file intact

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.
I wasn't able to get the local environment running as i was getting errors during installation and execution, the lack of instructions on how to get the local environment running didn't allow me to test further

## Checklist

- [ ] Documentation; N/A
- [ ] Storybook (if applicable); N/A
- [x] Tests;
- [x] Ready to be merged;

Some tests in the `useFiles.test.ts` or related might be failing as they check for the exact `{ code: value }`, but i feel like this was the wrong behaviour, i could test further if i could get assistance on how to run the local environment