### PR TITLE
fix: Fixed sandpackNode initializing failure

### DIFF
--- a/sandpack-client/src/clients/node/index.ts
+++ b/sandpack-client/src/clients/node/index.ts
@@ -202,6 +202,7 @@ export class SandpackNode extends SandpackClient {
       nullthrows(element, `The element '${selector}' was not found`);
 
       this.iframe = document.createElement("iframe");
+      element?.appendChild(this.iframe);
     } else {
       this.iframe = selector;
     }


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Bug fix

## What is the current behavior?

SandpackNode initializing with string selector ifame.parentNode will always be null, resulting in initialization failure
<img width="787" alt="image" src="https://github.com/codesandbox/sandpack/assets/21004230/413b243a-8e2b-4eb9-8f8b-898c43febd4e">


## What is the new behavior?

Fixed

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1.  Invoke loadSandpackClient with string selector
2. Ensure normal loading with no errors

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation; N/A
- [ ] Storybook (if applicable); N/A
- [ ] Tests; N/A
- [x] Ready to be merged;


<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
