### PR TITLE
fix(docs): Change Layout to Provider for accepting theme prop

### DIFF
--- a/website/docs/src/pages/advanced-usage/components.mdx
+++ b/website/docs/src/pages/advanced-usage/components.mdx
@@ -66,7 +66,7 @@ export default () => (
 `}
 </CodeBlock>
 
-`SandpackLayout` accepts a `theme` prop, so you can pass in your [custom theme object or a predefined theme](/themes).
+`SandpackProvider` accepts a `theme` prop, so you can pass in your [custom theme object or a predefined theme](/advanced-usage#sandpack-provider).
 
 ## Preview
 
@@ -575,19 +575,19 @@ export default () => (
 <details>
   <summary>`SandpackConsole` Options</summary>
 
-| Prop                    | Description                                                                              | Type                                  | Default              |
-| :---------------------- | :--------------------------------------------------------------------------------------- | :------------------------------------ | :------------------- |
-| `clientId`              |                                                                                          | `string`                              | `undefined`           |
-| `showHeader`            |                                                                                          | `boolean`                             | `true`               |
-| `showSyntaxError`       |                                                                                          | `boolean`                             | `false`              |
-| `showResetConsoleButton` |                                                                                         | `boolean`                             | `true`               |
-| `showRestartButton`     |                                                                                          | `boolean`                             | `true`               |
-| `maxMessageCount`       |                                                                                          | `number`                              | `800`                |
-| `onLogsChange`          |                                                                                          | `(logs: SandpackConsoleData) => void` |                      |
-| `resetOnPreviewRestart` | Reset the console list on every preview restart                                          | `boolean`                             | `false`              |
-| `ref`                   | Make possible to imperatively interact with the console component                        | `SandpackConsoleRef`                  | `SandpackConsoleRef` |
-| `standalone`            | It runs its sandpack-client, meaning it doesn't depend on a `SandpackPreview` component. | `boolean`                             | `false`              |
-| `actionsChildren`       |                                                                                          | JSX.Element                           | `null`               |
+| Prop                     | Description                                                                              | Type                                  | Default              |
+| :----------------------- | :--------------------------------------------------------------------------------------- | :------------------------------------ | :------------------- |
+| `clientId`               |                                                                                          | `string`                              | `undefined`          |
+| `showHeader`             |                                                                                          | `boolean`                             | `true`               |
+| `showSyntaxError`        |                                                                                          | `boolean`                             | `false`              |
+| `showResetConsoleButton` |                                                                                          | `boolean`                             | `true`               |
+| `showRestartButton`      |                                                                                          | `boolean`                             | `true`               |
+| `maxMessageCount`        |                                                                                          | `number`                              | `800`                |
+| `onLogsChange`           |                                                                                          | `(logs: SandpackConsoleData) => void` |                      |
+| `resetOnPreviewRestart`  | Reset the console list on every preview restart                                          | `boolean`                             | `false`              |
+| `ref`                    | Make possible to imperatively interact with the console component                        | `SandpackConsoleRef`                  | `SandpackConsoleRef` |
+| `standalone`             | It runs its sandpack-client, meaning it doesn't depend on a `SandpackPreview` component. | `boolean`                             | `false`              |
+| `actionsChildren`        |                                                                                          | JSX.Element                           | `null`               |
 
 </details>
 

--- a/website/docs/src/pages/advanced-usage/index.mdx
+++ b/website/docs/src/pages/advanced-usage/index.mdx
@@ -29,12 +29,13 @@ components that are exported by the main package (eg: `SandpackCodeEditor`,
 } from "@codesandbox/sandpack-react";
 
 const CustomSandpack = () => (
-  <SandpackProvider>
-    <SandpackLayout>
-      <SandpackCodeEditor />
-      <SandpackPreview />
-    </SandpackLayout>
-  </SandpackProvider>
+
+<SandpackProvider template="vanilla" theme="auto">
+  <SandpackLayout>
+    <SandpackCodeEditor />
+    <SandpackPreview />
+  </SandpackLayout>
+</SandpackProvider>
 );
 
 export default () => <CustomSandpack />


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Documentation Update

## What is the current behavior?

Right now the docs say the SandpackLayout component accepts the theme prop which is incorrect and the link following it also is invalid.
[1132](https://github.com/codesandbox/sandpack/issues/1132#issuecomment-2094105867)

## What is the new behavior?

Now the docs is updated. SandpackLayout is changed to SandpackProvider and and link also points to a proper page showing the example.


## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation;
- [ ] Storybook (if applicable);
- [ ] Tests;
- [ ] Ready to be merged;


<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
