### PR TITLE
Fix the installation command in docs

### DIFF
--- a/website/docs/src/pages/getting-started/index.mdx
+++ b/website/docs/src/pages/getting-started/index.mdx
@@ -7,21 +7,25 @@ import { CodeBlock } from "../../components/CodeBlock";
 Install the Sandpack dependency on your project.
 
 <Tabs items={["npm", "yarn", "pnpm"]}>
+
   <Tab>  
-```shell
+```bash
 npm i @codesandbox/sandpack-react
 ```
   </Tab>
 
-{" "}
-
-<Tab>```bash yarn add @codesandbox/sandpack-react ```</Tab>
+  <Tab>
+```bash
+yarn add @codesandbox/sandpack-react 
+```
+  </Tab>
 
   <Tab>
 ```bash
-pnpm i @codesandbox/sandpack-react 
+pnpm add @codesandbox/sandpack-react 
 ```
   </Tab>
+  
 </Tabs>
 
 All the components and the bundler are packed inside the `Sandpack` component, which is a named export of the package. Besides that, the package contains multiple **components**, **utilities** and **typings**.


### PR DESCRIPTION
## What kind of change does this pull request introduce?

<!-- Is it a Bug fix, feature, documentation update... -->
I fixed the installation command in [getting-started](https://sandpack.codesandbox.io/docs/getting-started) page.

## What is the current behavior?

![old sandpack](https://github.com/codesandbox/sandpack/assets/32416397/e41f356e-022b-465a-9a24-e2b040771921)


<!-- You can also link to an open issue here -->

## What is the new behavior?

![new sandpack](https://github.com/codesandbox/sandpack/assets/32416397/1f13a1e8-1cd5-48d5-b156-f40461000024)

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Step A
2. Step B
3. Step C

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation;
- [ ] Storybook (if applicable);
- [ ] Tests;
- [ ] Ready to be merged;


<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
