### PR TITLE
landing: change react website link

### DIFF
--- a/website/landing/website.config.json
+++ b/website/landing/website.config.json
@@ -127,7 +127,7 @@
       {
         "title": "React docs",
         "imageSource": "/assets/showcase/react-docs.jpg",
-        "url": "https://beta.reactjs.org/learn",
+        "url": "https://react.dev/learn",
         "description": "Want to try out a solution right on the same page alongside the guides or examples? With Sandpack you can embed a playground right into your documentation."
       },
       {
@@ -164,7 +164,7 @@
       },
       {
         "name": "React",
-        "socialUrl": "https://beta.reactjs.org/",
+        "socialUrl": "https://react.dev/",
         "logo": {
           "url": "/assets/logos/React.svg",
           "height": 50,


### PR DESCRIPTION
Changed react website link to the new domain.

## What kind of change does this pull request introduce?

Landing page link update.

## What is the current behavior?

It was using the legacy domain; which is reactjs.org

## What is the new behavior?

I changed it to react.dev.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

No tests required. I just changed the URL in website's config.

## Checklist

- [ ] Documentation; N/A
- [ ] Storybook (if applicable); N/A
- [ ] Tests; N/A
- [x] Ready to be merged;