### PR TITLE
fix(client): use stable sw id

### DIFF
--- a/sandpack-client/src/clients/runtime/types.ts
+++ b/sandpack-client/src/clients/runtime/types.ts
@@ -69,6 +69,7 @@ export type SandpackRuntimeMessage = BaseSandpackMessage &
         hasFileResolver: boolean;
         disableDependencyPreprocessing?: boolean;
         experimental_enableServiceWorker?: boolean;
+        experimental_stableServiceWorkerId?: string;
         template?: string | SandpackTemplate;
         showOpenInCodeSandbox: boolean;
         showErrorScreen: boolean;

--- a/sandpack-client/src/types.ts
+++ b/sandpack-client/src/types.ts
@@ -75,6 +75,7 @@ export interface ClientOptions {
    * Enable the service worker feature for sandpack-bundler
    */
   experimental_enableServiceWorker?: boolean;
+  experimental_stableServiceWorkerId?: string;
 }
 
 export interface SandboxSetup {

--- a/sandpack-react/src/Playground.stories.tsx
+++ b/sandpack-react/src/Playground.stories.tsx
@@ -11,10 +11,6 @@ export const Basic: React.FC = () => {
   return (
     <div style={{ height: "400vh" }}>
       <Sandpack
-        options={{
-          bundlerURL: "https://ymxnqs-3000.csb.app",
-        }}
-        template="react"
         customSetup={{
           dependencies: {
             "react-content-loader": "latest",
@@ -25,6 +21,10 @@ export const Basic: React.FC = () => {
             "react-table": "latest",
           },
         }}
+        options={{
+          bundlerURL: "https://ymxnqs-3000.csb.app",
+        }}
+        template="react"
       />
     </div>
   );

--- a/sandpack-react/src/PrivatePackage.stories.tsx
+++ b/sandpack-react/src/PrivatePackage.stories.tsx
@@ -34,8 +34,8 @@ export default function App() {
 }`,
         }}
         options={{
-          // bundlerURL: "https://t6jfwh-3000.csb.app/",
           experimental_enableServiceWorker: true,
+          experimental_enableStableServiceWorkerId: true,
         }}
         teamId="642af90c-4717-4730-bad3-e4c1e37ca5e2"
         template="react"

--- a/sandpack-react/src/PrivatePackage.stories.tsx
+++ b/sandpack-react/src/PrivatePackage.stories.tsx
@@ -14,11 +14,28 @@ export const Basic: React.FC = () => {
           dependencies: { "@codesandbox/test-package": "latest" },
         }}
         files={{
+          "/public/logo.svg": `<svg xmlns="http://www.w3.org/2000/svg" viewBox="-11.5 -10.23174 23 20.46348">
+          <title>React Logo</title>
+          <circle cx="0" cy="0" r="2.05" fill="#61dafb"/>
+          <g stroke="#61dafb" stroke-width="1" fill="none">
+            <ellipse rx="11" ry="4.2"/>
+            <ellipse rx="11" ry="4.2" transform="rotate(60)"/>
+            <ellipse rx="11" ry="4.2" transform="rotate(120)"/>
+          </g>
+        </svg>
+          `,
           "App.js": `import { Button } from "@codesandbox/test-package";
 
 export default function App() {
-  return <Button>Hello World</Button>
+  return <>
+    <Button>Hello World</Button>
+    <img width="100" src="/public/logo.svg" />
+  </>
 }`,
+        }}
+        options={{
+          // bundlerURL: "https://t6jfwh-3000.csb.app/",
+          experimental_enableServiceWorker: true,
         }}
         teamId="642af90c-4717-4730-bad3-e4c1e37ca5e2"
         template="react"

--- a/sandpack-react/src/contexts/utils/useClient.ts
+++ b/sandpack-react/src/contexts/utils/useClient.ts
@@ -174,6 +174,8 @@ export const useClient: UseClient = (
           teamId,
           experimental_enableServiceWorker:
             !!options?.experimental_enableServiceWorker,
+          experimental_stableServiceWorkerId:
+            options?.experimental_stableServiceWorkerId,
           sandboxId,
         }
       );

--- a/sandpack-react/src/contexts/utils/useClient.ts
+++ b/sandpack-react/src/contexts/utils/useClient.ts
@@ -19,8 +19,10 @@ import type {
   SandpackStatus,
 } from "../..";
 import { generateRandomId } from "../../utils/stringUtils";
+import { useAsyncSandpackId } from "../../utils/useAsyncSandpackId";
 
 import type { FilesState } from "./useFiles";
+
 type SandpackClientType = InstanceType<typeof SandpackClient>;
 
 const BUNDLER_TIMEOUT = 40_000;
@@ -115,6 +117,10 @@ export const useClient: UseClient = (
   const debounceHook = useRef<number | undefined>();
   const prevEnvironment = useRef(filesState.environment);
 
+  const experimental_stableServiceWorkerId = useAsyncSandpackId(
+    filesState.files
+  );
+
   /**
    * Callbacks
    */
@@ -175,7 +181,9 @@ export const useClient: UseClient = (
           experimental_enableServiceWorker:
             !!options?.experimental_enableServiceWorker,
           experimental_stableServiceWorkerId:
-            options?.experimental_stableServiceWorkerId,
+            options?.experimental_enableStableServiceWorkerId
+              ? await experimental_stableServiceWorkerId()
+              : undefined,
           sandboxId,
         }
       );

--- a/sandpack-react/src/presets/Sandpack.tsx
+++ b/sandpack-react/src/presets/Sandpack.tsx
@@ -73,8 +73,8 @@ export const Sandpack: SandpackInternal = ({
     logLevel: options.logLevel,
     classes: options.classes,
     experimental_enableServiceWorker: options.experimental_enableServiceWorker,
-    experimental_stableServiceWorkerId:
-      options.experimental_stableServiceWorkerId,
+    experimental_enableStableServiceWorkerId:
+      options.experimental_enableStableServiceWorkerId,
   };
 
   /**

--- a/sandpack-react/src/presets/Sandpack.tsx
+++ b/sandpack-react/src/presets/Sandpack.tsx
@@ -73,6 +73,8 @@ export const Sandpack: SandpackInternal = ({
     logLevel: options.logLevel,
     classes: options.classes,
     experimental_enableServiceWorker: options.experimental_enableServiceWorker,
+    experimental_stableServiceWorkerId:
+      options.experimental_stableServiceWorkerId,
   };
 
   /**

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -481,6 +481,7 @@ export interface SandpackInternalOptions<
   externalResources?: string[];
   classes?: Record<string, string>;
   experimental_enableServiceWorker?: boolean;
+  experimental_stableServiceWorkerId?: string;
 }
 
 interface SandpackInternalProps<

--- a/sandpack-react/src/types.ts
+++ b/sandpack-react/src/types.ts
@@ -481,7 +481,7 @@ export interface SandpackInternalOptions<
   externalResources?: string[];
   classes?: Record<string, string>;
   experimental_enableServiceWorker?: boolean;
-  experimental_stableServiceWorkerId?: string;
+  experimental_enableStableServiceWorkerId?: boolean;
 }
 
 interface SandpackInternalProps<

--- a/sandpack-react/src/utils/useAsyncSandpackId.ts
+++ b/sandpack-react/src/utils/useAsyncSandpackId.ts
@@ -1,0 +1,45 @@
+import type { SandpackBundlerFiles } from "@codesandbox/sandpack-client";
+import { useId as useReactId } from "react";
+
+import { generateRandomId } from "./stringUtils";
+
+/**
+ * This is a hard constraint to make URLs shorter.
+ * For example, this id will be used to mount SW in the iframe
+ * so, to keep the URL valid, this must be an 9 character long string
+ */
+const MAX_ID_LENGTH = 9;
+
+export const useAsyncSandpackId = (files: SandpackBundlerFiles) => {
+  if (typeof useReactId === "function") {
+    /* eslint-disable-next-line react-hooks/rules-of-hooks */
+    const id = useReactId();
+    return async () => {
+      const allCode = Object.entries(files)
+        .map((path, code) => path + "|" + code)
+        .join("|||");
+      const sha = await generateShortId(allCode + id);
+
+      return ensureLength(sha.replace(/:/g, "sp"), MAX_ID_LENGTH);
+    };
+  } else {
+    return generateRandomId();
+  }
+};
+
+function ensureLength(str: string, length: number) {
+  if (str.length > length) {
+    return str.slice(0, length);
+  } else {
+    return str.padEnd(length, "s");
+  }
+}
+
+async function generateShortId(input: string) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(input);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+
+  return btoa(String.fromCharCode(...hashArray));
+}

--- a/sandpack-react/src/utils/useAsyncSandpackId.ts
+++ b/sandpack-react/src/utils/useAsyncSandpackId.ts
@@ -13,17 +13,17 @@ const MAX_ID_LENGTH = 9;
 export const useAsyncSandpackId = (files: SandpackBundlerFiles) => {
   if (typeof useReactId === "function") {
     /* eslint-disable-next-line react-hooks/rules-of-hooks */
-    const id = useReactId();
+    const reactDomId = useReactId();
     return async () => {
       const allCode = Object.entries(files)
         .map((path, code) => path + "|" + code)
         .join("|||");
-      const sha = await generateShortId(allCode + id);
+      const sha = await generateShortId(allCode + reactDomId);
 
       return ensureLength(sha.replace(/:/g, "sp"), MAX_ID_LENGTH);
     };
   } else {
-    return generateRandomId();
+    return ensureLength(generateRandomId(), MAX_ID_LENGTH);
   }
 };
 

--- a/sandpack-react/src/utils/useAsyncSandpackId.ts
+++ b/sandpack-react/src/utils/useAsyncSandpackId.ts
@@ -23,7 +23,7 @@ export const useAsyncSandpackId = (files: SandpackBundlerFiles) => {
       return ensureLength(sha.replace(/:/g, "sp"), MAX_ID_LENGTH);
     };
   } else {
-    return ensureLength(generateRandomId(), MAX_ID_LENGTH);
+    return () => ensureLength(generateRandomId(), MAX_ID_LENGTH);
   }
 };
 

--- a/website/docs/src/pages/advanced-usage/serving-static-files.mdx
+++ b/website/docs/src/pages/advanced-usage/serving-static-files.mdx
@@ -14,6 +14,7 @@ By enabling this feature, Sandpack will register a new Service Worker in the ifr
 <SandpackProvider
   options={{
     experimental_enableServiceWorker: true,
+    experimental_enableStableServiceWorkerId: false // set this true, in case private package are used
   }}
 >
   {...}


### PR DESCRIPTION
When using Private Package, Sandpack needs a deterministic bundler URL to persist the authentication token in the cookies. Clearly, this is not compatible with how SW works because it needs unique URLs by sandbox. 

So, this implements a new feature to generate a deterministic short id based on the `useId` React hook (DOM location-based and probably more), and an SHA generated by files. I believe this should be okay to avoid conflicts between sandboxes.