### PR TITLE
docs: fix SandpackTests options table display

### DIFF
--- a/website/docs/src/pages/advanced-usage/components.mdx
+++ b/website/docs/src/pages/advanced-usage/components.mdx
@@ -461,10 +461,11 @@ export default () => (
 <details>
   <summary>Options</summary>
 
-| Prop | Description | Type | Default |
-| `verbose` | Display individual test results with the test suite hierarchy. | `boolean` | `false`|
-| `watchMode` | Watch files for changes and rerun all tests. Note if changing a test file then the current file will run on it's own | `boolean` | `true` |
-| `onComplete` | A callback that is invoked with the completed specs. | Function | `undefined` |
+| Prop         | Description                                                                                                          | Type      | Default     |
+| :----------- | :------------------------------------------------------------------------------------------------------------------- | :-------- | :---------- |
+| `verbose`    | Display individual test results with the test suite hierarchy.                                                       | `boolean` | `false`     |
+| `watchMode`  | Watch files for changes and rerun all tests. Note if changing a test file then the current file will run on it's own | `boolean` | `true`      |
+| `onComplete` | A callback that is invoked with the completed specs.                                                                 | Function  | `undefined` |
 
 </details>
 


### PR DESCRIPTION
## What kind of change does this pull request introduce?

The options table for SandpackTests in the documentation has been modified as it was not displaying correctly.

You can check it here: https://sandpack.codesandbox.io/docs/advanced-usage/components#tests

|AS-IS|TO-BE|
|---|---|
|<img width="796" alt="image" src="https://github.com/user-attachments/assets/e0655ddc-7e39-4878-a2ed-b9ccb0b2cedf">|<img width="794" alt="image" src="https://github.com/user-attachments/assets/03a7783b-3e88-45fe-9f8c-bf8c43a4eb8d">|

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation;
- [ ] Storybook (if applicable);
- [ ] Tests;
- [ ] Ready to be merged;

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
