### PR TITLE
fix: handle string errors in SandpackTests component

### DIFF
--- a/sandpack-react/src/components/Tests/FormattedError.tsx
+++ b/sandpack-react/src/components/Tests/FormattedError.tsx
@@ -44,7 +44,7 @@ const escapeHtml = (unsafe: string): string => {
 const formatDiffMessage = (error: TestError, path: string): string => {
   let finalMessage = "";
   if (error.matcherResult) {
-    finalMessage = `<span>${escapeHtml(error.message)
+    finalMessage = `<span>${escapeHtml(error.message ?? "")
       .replace(/(expected)/m, `<span class="${passTextClassName}">$1</span>`)
       .replace(/(received)/m, `<span class="${failTextClassName}">$1</span>`)
       .replace(/(Difference:)/m, `<span>$1</span>`)
@@ -62,7 +62,7 @@ const formatDiffMessage = (error: TestError, path: string): string => {
         `<span class="${passTextClassName}">$1</span>`
       )}</span>`;
   } else {
-    finalMessage = escapeHtml(error.message);
+    finalMessage = escapeHtml(error.message ?? "");
   }
 
   if (


### PR DESCRIPTION
close https://github.com/codesandbox/sandpack/issues/1113

## What kind of change does this pull request introduce?

The SandpackTests component was crashing when throwing a string instead of an Error instance.

### Cause
The problem occurred because `error.message` was `undefined`, causing the escapeHtml function to fail when attempting to replace.

### Solution
Implemented nullish handling to safely process cases where error.message is undefined.


#### AS-IS

https://github.com/user-attachments/assets/ce317d3e-223a-42fc-ab1e-c641bed7fa0a


#### TO-BE

https://github.com/user-attachments/assets/4f1a9f27-9fd2-4044-b99f-32c44e0fd1c9



## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation;
- [ ] Storybook (if applicable);
- [ ] Tests;
- [ ] Ready to be merged;

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
