### PR TITLE
allow using Storage Access API in the sandboxed iframe

### DIFF
--- a/sandpack-client/src/clients/runtime/index.ts
+++ b/sandpack-client/src/clients/runtime/index.ts
@@ -81,7 +81,7 @@ export class SandpackRuntime extends SandpackClient {
     if (!this.iframe.getAttribute("sandbox")) {
       this.iframe.setAttribute(
         "sandbox",
-        "allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts allow-downloads allow-pointer-lock"
+        "allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-downloads allow-pointer-lock"
       );
 
       this.iframe.setAttribute(

--- a/sandpack-client/src/clients/static/index.ts
+++ b/sandpack-client/src/clients/static/index.ts
@@ -81,7 +81,7 @@ export class SandpackStatic extends SandpackClient {
     if (!this.iframe.getAttribute("sandbox")) {
       this.iframe.setAttribute(
         "sandbox",
-        "allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts allow-downloads allow-pointer-lock"
+        "allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-downloads allow-pointer-lock"
       );
 
       this.iframe.setAttribute(


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Improvement. I'm adding allow-storage-access-by-user-activation to allow Storage Access API requests.
These changes close https://github.com/codesandbox/sandpack/issues/1215

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation;
- [ ] Storybook (if applicable);
- [ ] Tests;
- [ ] Ready to be merged;

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
