### PR TITLE
fix: replace eval with globalThis to comply with CSP policies

### DIFF
--- a/sandpack-react/src/components/Console/utils/transformers.ts
+++ b/sandpack-react/src/components/Console/utils/transformers.ts
@@ -3,11 +3,17 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // Const
-const GLOBAL = (function getGlobal() {
-  // NOTE: see http://www.ecma-international.org/ecma-262/6.0/index.html#sec-performeval step 10
-  const savedEval = eval;
+const GLOBAL = (function getGlobal(): any {
+  if (typeof globalThis !== "undefined") return globalThis; // modern standard
 
-  return savedEval("this");
+  if (typeof window !== "undefined") return window; // browser
+
+  if (typeof global !== "undefined") return global; // Node.js
+
+  // eslint-disable-next-line no-restricted-globals
+  if (typeof self !== "undefined") return self; // Web Worker
+
+  throw Error("Unable to locate global object");
 })();
 
 const ARRAY_BUFFER_SUPPORTED = typeof ArrayBuffer === "function";


### PR DESCRIPTION
## What kind of change does this pull request introduce?
**Issue:**
Sandpack currently uses `eval` to obtain the global object, which triggers CSP `unsafe-eval` violations. This poses security risks and limits the ability to use Sandpack in environments with strict CSP policies.

**Solution:**
Replaced the `eval`-based approach with an IIFE that sequentially checks for `globalThis`, `self`, `window`, and `global` to securely access the global object without violating CSP policies.

**Testing:**
Tested in a local development environment with CSP enforced to ensure no violations occur.

**Related Issue:**
https://github.com/codesandbox/sandpack/issues/1221

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation; N/A
- [ ] Storybook (if applicable); N/A
- [x] Tests;
- [x] Ready to be merged;

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
