### PR TITLE
fix(landing): invalid isMounted judgment

### DIFF
--- a/website/landing/components/Hero/HeroDesktop/HeroDesktop.tsx
+++ b/website/landing/components/Hero/HeroDesktop/HeroDesktop.tsx
@@ -22,7 +22,7 @@ export const HeroDesktop: React.FC = () => {
   const [scrollPosition, setScrollPosition] = useState(scrollY.get());
   const scrollHeight = useMemo(() => sectionHeight / 3, [sectionHeight]);
   const [animationComplete, setAnimationComplete] = useState(false);
-  const isMounted = useRef(false);
+  const isMountedRef = useRef(false);
 
   scrollY.onChange((updatedScroll) => setScrollPosition(updatedScroll));
 
@@ -102,9 +102,9 @@ export const HeroDesktop: React.FC = () => {
   }, [sectionRef]);
 
   useLayoutEffect(() => {
-    if (isMounted.current) return;
+    if (isMountedRef.current) return;
 
-    isMounted.current = !!sectionRef.current;
+    isMountedRef.current = !!sectionRef.current;
   }, [sectionRef]);
 
   useEffect(() => {
@@ -154,6 +154,8 @@ export const HeroDesktop: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [animationComplete]);
 
+  const isMounted = isMountedRef.current;
+
   return (
     <AnimatedBox
       ref={sectionRef}
@@ -180,7 +182,7 @@ export const HeroDesktop: React.FC = () => {
           position: "sticky",
           top: 0,
           transform: "scale($container-scale)",
-          opacity: isMounted.current ? 1 : 0,
+          opacity: isMounted ? 1 : 0,
           transition: "opacity 300ms linear",
 
           display: "flex",


### PR DESCRIPTION
## What kind of change does this pull request introduce?
In file `website/landing/components/Hero/HeroDesktop/HeroDesktop.tsx`, isMounted always return true
```js
   const isMountedRef = useRef(false);
    ...
    <AnimatedBox
      ref={sectionRef}
      css={{ height: "200vh" }}
      id="container"
      style={
        {
          "--progress": isMounted ? progress : 0,
          "--opacity": isMounted ? opacity : 1,
          "--progress-inverse": isMounted ? progressInverse : 1,
          "--rotate": isMounted ? rotate : -90,
          "--scale": isMounted ? scale : 2.08,
          "--container-scale": isMounted ? containerScale : 1,
          "--sandpack-preview-opacity": isMounted ? sandpackPreviewOpacity : 0,
          // eslint-disable-next-line @typescript-eslint/no-explicit-any
        } as any
      }
    >
```

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation;
- [ ] Storybook (if applicable);
- [x] Tests;
- [x] Ready to be merged;

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
