### PR TITLE
minifix(code editor): column 0 in decorators

### DIFF
--- a/sandpack-react/src/components/CodeEditor/CodeMirror.stories.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.stories.tsx
@@ -152,6 +152,7 @@ export default function List() {
       decorators={[
         { className: "highlight", line: 1 },
         { className: "highlight", line: 9 },
+        { className: "highlight", line: 11, startColumn: 1, endColumn: 2 },
         { className: "highlight", line: 11, startColumn: 0, endColumn: 1 },
         {
           className: "widget",

--- a/sandpack-react/src/components/CodeEditor/CodeMirror.stories.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.stories.tsx
@@ -152,6 +152,7 @@ export default function List() {
       decorators={[
         { className: "highlight", line: 1 },
         { className: "highlight", line: 9 },
+        { className: "highlight", line: 11, startColumn: 0, endColumn: 1 },
         {
           className: "widget",
           elementAttributes: { "data-id": "2" },

--- a/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
+++ b/sandpack-react/src/components/CodeEditor/CodeMirror.tsx
@@ -178,7 +178,11 @@ export const CodeMirror = React.forwardRef<CodeMirrorRef, CodeMirrorProps>(
     const sortedDecorators = React.useMemo(
       () =>
         decorators
-          ? decorators.sort((d1, d2) => d1.line - d2.line)
+          ? decorators.sort(
+              (d1, d2) =>
+                d1.line - d2.line ||
+                (d1.startColumn ?? 0) - (d2.startColumn ?? 0)
+            )
           : decorators,
       [decorators]
     );

--- a/sandpack-react/src/components/CodeEditor/highlightDecorators.ts
+++ b/sandpack-react/src/components/CodeEditor/highlightDecorators.ts
@@ -38,7 +38,7 @@ export function highlightDecorators(positions: Decorators): Extension {
               column: item.startColumn,
             }) + 1;
 
-          if (item.startColumn && item.endColumn) {
+          if (item.startColumn !== undefined && item.endColumn !== undefined) {
             const positionLineEnd =
               getCodeMirrorPosition(view.state.doc, {
                 line: item.line,

--- a/sandpack-react/src/components/CodeViewer/CodeViewer.stories.tsx
+++ b/sandpack-react/src/components/CodeViewer/CodeViewer.stories.tsx
@@ -99,6 +99,7 @@ export default function List() {
         <SandpackCodeViewer
           decorators={[
             { className: "highlight", line: 1 },
+            { className: "highlight", line: 11, startColumn: 0, endColumn: 1 },
             { className: "highlight", line: 9 },
             {
               className: "widget",


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Fix handling of `columnStart: 0` in decorators.  
Without this change, using `columnStart: 0` always results in the entire line being part of the range (ex: the entire line is highlighted).  
The second commit is for the same issue as #383.

## Checklist
Did not find relevant tests to add to.
<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation N/A;
- [x] Storybook (if applicable);
- [x] Tests N/A;
- [x] Ready to be merged;

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
