### PR TITLE
Fix typo: 'Clinet' → 'Client' in architecture overview

### DIFF
--- a/website/docs/src/pages/architecture/overview.mdx
+++ b/website/docs/src/pages/architecture/overview.mdx
@@ -7,7 +7,7 @@ import { Mermaid } from 'mdx-mermaid/Mermaid';
 - `<Sandpack />` component initializes
 - Manages React integration & UI state
 
-2. Sandpack Clinet
+2. Sandpack Client
 
 - `loadSandpackClient()` selects appropriate client type (VM/Runtime/Static/Node)
 - Creates sandbox context from files, template, and dependencies


### PR DESCRIPTION
## What kind of change does this pull request introduce?

Fixes a typo in the architecture overview docs: `Sandpack Clinet` → `Sandpack Client` (line 10 of `website/docs/src/pages/architecture/overview.mdx`).

## Checklist

- [x] Documentation;
- N/A Storybook (if applicable);
- N/A Tests;
- [x] Ready to be merged;