### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup | Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "14.18.0"
+          node-version: "18"
 
       - name: Setup | Authenticate with Registry
         run: echo //npm.pkg.github.com/:_authToken=${NPM_TOKEN} > .npmrc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup | Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "16.14.0"
+          node-version: "18"
 
       - name: Install dependencies and cache
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `18`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `node-version` pins so they satisfy `18` (using `18` where a concrete pin is needed).

- `.github/workflows/release-canary.yml`
  - `node-version: "14.18.0"` → `node-version: "18"`
- `.github/workflows/release.yml`
  - `node-version: "16.14.0"` → `node-version: "18"`

## Test plan
- [ ] Package `engines.node` / `volta.node` / `.nvmrc` is still `18`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
